### PR TITLE
Need to flatten regression outputs to 1d

### DIFF
--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -266,7 +266,7 @@ function predict_regression((fitted_model, classes), Xnew)
 
     Xnew = MLJModelInterface.matrix(Xnew)
     # the Float64. effectly copies the array, because otherwise it stays as a "reshape" object
-    return Float64.(dropdims(LightGBM.predict(fitted_model, Xnew), dims=2))
+    return LightGBM.predict(fitted_model, Xnew)
 
 end
 

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -31,9 +31,8 @@ function predict(
         estimator.booster, X, predict_type, num_iterations, is_row_major
     )
 
-    num_classes = get_num_classes(estimator)
     # This works the same one way or another because when n=1, reshaping is basically no-op
-    prediction  = transpose(reshape(prediction, num_classes, :))
+    prediction = prediction_reshaper(estimator, prediction)
 
     return prediction
 
@@ -56,5 +55,12 @@ function predict_classes(
 
 end
 
-get_num_classes(estimator::LGBMEstimator) = 1
-get_num_classes(estimator::LGBMMulticlass) = estimator.num_class
+
+@inline function prediction_reshaper(estimator::LGBMMulticlass, prediction::AbstractVector{Float64})
+
+    num_classes = estimator.num_class
+    return transpose(reshape(prediction, num_classes, :))
+
+end
+@inline prediction_reshaper(estimator::LGBMEstimator, prediction::AbstractVector{Float64}) = prediction
+


### PR DESCRIPTION
As title, regression outputs being "2-d" doesn't play nicely with type signatures of typical loss functions