### PR TITLE
Mlj num classes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 MLJModelInterface = "^0.2"
-StatsBase = "0.32"
+StatsBase = "^0.32,^0.33"
 julia = "1.0"
 
 [extras]

--- a/src/LightGBM.jl
+++ b/src/LightGBM.jl
@@ -21,6 +21,6 @@ function __init__()
 end
 
 export fit, predict, predict_classes, cv, search_cv, savemodel, loadmodel
-export LGBMEstimator, LGBMRegression, LGBMBinary, LGBMMulticlass
+export LGBMEstimator, LGBMRegression, LGBMClassification
 
 end # module LightGBM

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -12,8 +12,18 @@ const LGBM_METRICS = (
     "xentlambda", "kullback_leibler", "kldiv",
 )
 
+const CLASSIFICATION_OBJECTIVES = (
+    "binary", "multiclass", "softmax", "multiclassova", "multiclass_ova", "ova", "ovr",
+)
 
-MLJModelInterface.@mlj_model mutable struct LGBMRegression <: MLJModelInterface.Deterministic
+const REGRESSION_OBJECTIVES = (
+    "regression", "regression_l2", "l2", "mean_squared_error", "mse", "l2_root", "root_mean_squared_error", "rmse",
+    "regression_l1", "l1", "mean_absolute_error", "mae", "huber", "fair", "poisson", "quantile", "mape",
+    "mean_absolute_percentage_error", "gamma", "tweedie",
+)
+
+
+MLJModelInterface.@mlj_model mutable struct LGBMRegressor <: MLJModelInterface.Deterministic
 
     # Hyperparameters, see https://lightgbm.readthedocs.io/en/latest/Parameters.html for defaults
     num_iterations::Int = 10::(_ >= 0)
@@ -37,6 +47,7 @@ MLJModelInterface.@mlj_model mutable struct LGBMRegression <: MLJModelInterface.
     init_score::String = ""
 
     # Model properties
+    objective::String = "regression"::(_ in REGRESSION_OBJECTIVES)
     categorical_feature::Vector{Int} = Vector{Int}()
     data_random_seed::Int = 1
     is_sparse::Bool = true
@@ -44,60 +55,6 @@ MLJModelInterface.@mlj_model mutable struct LGBMRegression <: MLJModelInterface.
 
     # Metrics
     metric::Vector{String} = ["l2"]::(all(in.(_, (LGBM_METRICS, ))))
-    metric_freq::Int = 1::(_ > 0)
-    is_training_metric::Bool = false
-    ndcg_at::Vector{Int} = Vector{Int}([1, 2, 3, 4, 5])::(all(_ .> 0))
-
-    # Implementation parameters
-    num_machines::Int = 1::(_ > 0)
-    num_threads::Int  = 0::(_ >= 0)
-    local_listen_port::Int = 12400::(_ > 0)
-    time_out::Int = 120::(_ > 0)
-    machine_list_file::String = ""
-    save_binary::Bool = false
-    device_type::String = "cpu"::(_ in ("cpu", "gpu"))
-
-end
-
-
-MLJModelInterface.@mlj_model mutable struct LGBMBinary <: MLJModelInterface.Probabilistic
-
-    # Hyperparameters, see https://lightgbm.readthedocs.io/en/latest/Parameters.html for defaults
-    num_iterations::Int = 10::(_ >= 0)
-    learning_rate::Float64 = 0.1::(_ > 0.)
-    num_leaves::Int = 31::(1 < _ <= 131072)
-    max_depth::Int = -1;#::(_ != 0);
-    tree_learner::String = "serial"::(_ in ("serial", "feature", "data", "voting"))
-    histogram_pool_size::Float64 = -1.0;#::(_ != 0.0);
-    min_data_in_leaf::Int = 20::(_ >= 0)
-    min_sum_hessian_in_leaf::Float64 = 1e-3::(_ >= 0.0)
-    lambda_l1::Float64 = 0.0::(_ >= 0.0)
-    lambda_l2::Float64 = 0.0::(_ >= 0.0)
-    min_gain_to_split::Float64 = 0.0::(_ >= 0.0)
-    feature_fraction::Float64 = 1.0::(0.0 < _ <= 1.0)
-    feature_fraction_seed::Int = 2
-    bagging_fraction::Float64 = 1.0::(0.0 < _ <= 1.0)
-    bagging_freq::Int = 0::(_ >= 0)
-    bagging_seed::Int = 3
-    early_stopping_round::Int = 0
-    max_bin::Int = 255::(_ > 1)
-    init_score::String = ""
-
-    # For documentation purposes: A calibration scaling factor for the output probabilities for binary and multiclass OVA
-    # Not included above because this is only present for the binary model in the FFI wrapper
-    sigmoid::Float64 = 1.0::(_ > 0.0 )
-
-    # Model properties
-    categorical_feature::Vector{Int} = Vector{Int}();
-    data_random_seed::Int = 1
-    is_sparse::Bool = true
-    is_unbalance::Bool = false
-
-    # Only accepted in the interface for Multiclass
-    #num_class::Int = 1::(_ > 0)
-
-    # Metrics
-    metric::Vector{String} = ["binary_error"]::(all(in.(_, (LGBM_METRICS, ))))
     metric_freq::Int = 1::(_ > 0)
     is_training_metric::Bool = false
     ndcg_at::Vector{Int} = Vector{Int}([1, 2, 3, 4, 5])::(all(_ .> 0))
@@ -142,17 +99,14 @@ MLJModelInterface.@mlj_model mutable struct LGBMClassifier <: MLJModelInterface.
     # sigmoid::Float64 = 1.0::(_ > 0.0 )
 
     # Model properties
+    objective::String = "multiclass"::(_ in CLASSIFICATION_OBJECTIVES)
     categorical_feature::Vector{Int} = Vector{Int}();
     data_random_seed::Int = 1
     is_sparse::Bool = true
     is_unbalance::Bool = false
 
-    # Only accepted in the interface for Multiclass
-    # LightGBM itself will throw if left at the default value
-    num_class::Int = 1::(_ > 0)
-
     # Metrics
-    metric::Vector{String} = ["multi_error"]::(all(in.(_, (LGBM_METRICS, ))))
+    metric::Vector{String} = ["None"]::(all(in.(_, (LGBM_METRICS, ))))
     metric_freq::Int = 1::(_ > 0)
     is_training_metric::Bool = false
     ndcg_at::Vector{Int} = Vector{Int}([1, 2, 3, 4, 5])::(all(_ .> 0))
@@ -169,11 +123,10 @@ MLJModelInterface.@mlj_model mutable struct LGBMClassifier <: MLJModelInterface.
 end
 
 
-CLASSIFIERS = Union{LGBMBinary, LGBMClassifier}
-MODELS = Union{LGBMBinary, LGBMClassifier, LGBMRegression}
+MODELS = Union{LGBMClassifier, LGBMRegressor}
 
 
-function mlj_to_kwargs(model::MLJModelInterface.Supervised)
+function mlj_to_kwargs(model::LGBMRegressor)
 
     return Dict{Symbol, Any}(
         name => getfield(model, name)
@@ -182,9 +135,16 @@ function mlj_to_kwargs(model::MLJModelInterface.Supervised)
 
 end
 
-function mlj_to_kwargs(model::MLJModelInterface.Supervised, classes)
+function mlj_to_kwargs(model::LGBMClassifier, classes)
 
     num_class = length(classes)
+    if model.objective == "binary"
+        if num_class != 2
+            throw(ArgumentError("binary objective number of classes $num_class greater than 2"))
+        end
+        # munge num_class for LightGBM
+        num_class = 1
+    end
 
     retval = Dict{Symbol, Any}(
         name => getfield(model, name)
@@ -196,7 +156,7 @@ function mlj_to_kwargs(model::MLJModelInterface.Supervised, classes)
 
 end
 
-# X and y must be untyped per MLJ docs (and probably w too, getting nothing by default is zzz though)
+# X and y and w must be untyped per MLJ docs
 function fit(mlj_model::MODELS, verbosity::Int, X, y, w=Vector{AbstractFloat}())
 
     # MLJ docs are clear that 0 means silent. but 0 in LightGBM world means "warnings"
@@ -208,66 +168,42 @@ function fit(mlj_model::MODELS, verbosity::Int, X, y, w=Vector{AbstractFloat}())
     X = MLJModelInterface.matrix(X)
     # The FFI wrapper wants Float32 for these
     w = Float32.(w)
-    report = LightGBM.fit(model, X, y_lgbm; verbosity=verbosity, weights=w)
+    report = LightGBM.fit!(model, X, y_lgbm; verbosity=verbosity, weights=w)
 
     model = (model, classes)
     cache = nothing
     report = (report,)
 
     # Caution: The model is a pointer to a memory location including its training data
-    # which is probably bum ... fix in LightGBM.jl?
+    # This definitely needs fixing
     return (model, cache, report)
 
 end
 
 
 # This does prep for classification tasks
-@inline function prepare_targets(
-    targets,
-    model::CLASSIFIERS)
+@inline function prepare_targets(targets, model::LGBMClassifier)
 
     classes = MLJModelInterface.classes(first(targets))
-    check_classes(model, classes)
     # -1 because these will be 1,2 and LGBM uses the 0/1 boundary
-    # -This also works for multiclass because the classes ae 0 indexed
+    # -This also works for multiclass because the classes are 0 indexed
     targets = Float64.(MLJModelInterface.int(targets) .- 1)
     return targets, classes
 
 end
-
-
 # This does prep for Regression, which is basically a no-op (or rather, just creation of an empty placeholder classes object
-@inline function prepare_targets(
-    targets::AbstractVector,
-    model::LGBMRegression)
-
-    return targets, []
-
-end
+@inline prepare_targets(targets::AbstractVector, model::LGBMRegressor) = targets, []
 
 
-function check_classes(model::MLJInterface.LGBMBinary, classes)::Nothing
-    if length(classes) > 2
-        throw(ErrorException("Binary classification with $(length(classes)) categories"))
+function predict_classifier((fitted_model, classes), Xnew)
+
+    Xnew = MLJModelInterface.matrix(Xnew)
+    predicted = LightGBM.predict(fitted_model, Xnew)
+    # when the objective == binary, lightgbm internally has classes = 1 and spits out only probability of positive class
+    if size(predicted, 2) == 1
+        predicted = hcat(1. .- predicted, predicted)
     end
-    return nothing
-end
-check_classes(model::MODELS, classes)::Nothing = nothing
 
-
-function predict_binary((fitted_model, classes), Xnew)
-
-    Xnew = MLJModelInterface.matrix(Xnew)
-    predicted = LightGBM.predict(fitted_model, Xnew)
-    return [MLJModelInterface.UnivariateFinite(classes, [1 - pred, pred]) for pred in predicted]
-
-end
-
-function predict_multi((fitted_model, classes), Xnew)
-
-    Xnew = MLJModelInterface.matrix(Xnew)
-    predicted = LightGBM.predict(fitted_model, Xnew)
-    # much rather use `eachrow` here but it requires julia >= 1.1 and thats probably not cool
     return [MLJModelInterface.UnivariateFinite(classes, predicted[row, :]) for row in 1:size(predicted, 1)]
 
 end
@@ -275,45 +211,35 @@ end
 function predict_regression((fitted_model, classes), Xnew)
 
     Xnew = MLJModelInterface.matrix(Xnew)
-    # the Float64. effectly copies the array, because otherwise it stays as a "reshape" object
     return LightGBM.predict(fitted_model, Xnew)
 
 end
+
 
 # multiple dispatch the various signatures for each model and args combo
 MLJModelInterface.fit(model::MLJInterface.MODELS, verbosity::Int, X, y) = MLJInterface.fit(model, verbosity, X, y)
 MLJModelInterface.fit(model::MLJInterface.MODELS, verbosity::Int, X, y, w::Nothing) = MLJInterface.fit(model, verbosity, X, y)
 MLJModelInterface.fit(model::MLJInterface.MODELS, verbosity::Int, X, y, w) = MLJInterface.fit(model, verbosity, X, y, w)
 
-MLJModelInterface.predict(model::MLJInterface.LGBMBinary, fitresult, Xnew) = MLJInterface.predict_binary(fitresult, Xnew)
-MLJModelInterface.predict(model::MLJInterface.LGBMClassifier, fitresult, Xnew) = MLJInterface.predict_multi(fitresult, Xnew)
-MLJModelInterface.predict(model::MLJInterface.LGBMRegression, fitresult, Xnew) = MLJInterface.predict_regression(fitresult, Xnew)
+MLJModelInterface.predict(model::MLJInterface.LGBMClassifier, fitresult, Xnew) = MLJInterface.predict_classifier(fitresult, Xnew)
+MLJModelInterface.predict(model::MLJInterface.LGBMRegressor, fitresult, Xnew) = MLJInterface.predict_regression(fitresult, Xnew)
 
 # multiple dispatch the model initialiser functions
-model_init(mlj_model::MLJInterface.LGBMBinary, classes) = LightGBM.LGBMBinary(; mlj_to_kwargs(mlj_model)...)
-model_init(mlj_model::MLJInterface.LGBMClassifier, classes) = LightGBM.LGBMMulticlass(; mlj_to_kwargs(mlj_model, classes)...)
-model_init(mlj_model::MLJInterface.LGBMRegression, targets) = LightGBM.LGBMRegression(; mlj_to_kwargs(mlj_model)...)
+model_init(mlj_model::MLJInterface.LGBMClassifier, classes) = LightGBM.LGBMClassification(; mlj_to_kwargs(mlj_model, classes)...)
+model_init(mlj_model::MLJInterface.LGBMRegressor, targets) = LightGBM.LGBMRegression(; mlj_to_kwargs(mlj_model)...)
 
 
 # metadata
 MLJModelInterface.metadata_pkg.(
-    (LGBMBinary, LGBMClassifier, LGBMRegression); # end positional args
+    (LGBMClassifier, LGBMRegressor); # end positional args
     name="LightGBM",
-    uuid="50415d55-5a07-4c42-a30b-abdb22ba6b8f",
+    uuid="7acf609c-83a4-11e9-1ffb-b912bcd3b04a",
     url="https://github.com/IQVIA-ML/LightGBM.jl",
     julia=false,
     license="MIT Expat",
     is_wrapper=true,
 )
 
-MLJModelInterface.metadata_model(
-    LGBMBinary; # end positional args
-    path="LightGBM.MLJInterface.LGBMBinary",
-    input=MLJModelInterface.Table(MLJModelInterface.Continuous),
-    target=AbstractVector{<:MLJModelInterface.Finite},
-    weights=true,
-    descr="Microsoft LightGBM FFI wrapper: Binary classifier",
-)
 
 MLJModelInterface.metadata_model(
     LGBMClassifier; # end positional args
@@ -321,16 +247,16 @@ MLJModelInterface.metadata_model(
     input=MLJModelInterface.Table(MLJModelInterface.Continuous),
     target=AbstractVector{<:MLJModelInterface.Finite},
     weights=true,
-    descr="Microsoft LightGBM FFI wrapper: Multiclass classifier",
+    descr="Microsoft LightGBM FFI wrapper: Classifier",
 )
 
 MLJModelInterface.metadata_model(
-    LGBMRegression; # end positional args
-    path="LightGBM.MLJInterface.LGBMRegression",
+    LGBMRegressor; # end positional args
+    path="LightGBM.MLJInterface.LGBMRegressor",
     input=MLJModelInterface.Table(MLJModelInterface.Continuous),
     target=AbstractVector{MLJModelInterface.Continuous},
     weights=true,
-    descr="Microsoft LightGBM FFI wrapper: Regression",
+    descr="Microsoft LightGBM FFI wrapper: Regressor",
 )
 
 end # module

--- a/src/cv.jl
+++ b/src/cv.jl
@@ -44,7 +44,7 @@ function cv(estimator::LGBMEstimator, X::Matrix{TX}, y::Vector{Ty}, splits;
         estimator.booster = LGBM_BoosterCreate(train_ds, bst_parameters)
         LGBM_BoosterAddValidData(estimator.booster, test_ds)
 
-        results = train(estimator, ["validation"], verbosity, start_time)
+        results = train!(estimator, ["validation"], verbosity, start_time)
 
         for dataset in keys(results)
             dataset_results = results[dataset]

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -50,227 +50,100 @@ mutable struct LGBMRegression <: LGBMEstimator
 end
 
 """
-    LGBMRegression(; [num_iterations = 10,
-                      learning_rate = .1,
-                      num_leaves = 127,
-                      max_depth = -1,
-                      tree_learner = \"serial\",
-                      num_threads = Sys.CPU_THREADS,
-                      histogram_pool_size = -1.,
-                      min_data_in_leaf = 100,
-                      min_sum_hessian_in_leaf = 10.,
-                      lambda_l1 = 0.,
-                      lambda_l2 = 0.,
-                      min_gain_to_split = 0.,
-                      feature_fraction = 1.,
-                      feature_fraction_seed = 2,
-                      bagging_fraction = 1.,
-                      bagging_freq = 0,
-                      bagging_seed = 3,
-                      early_stopping_round = 0,
-                      max_bin = 255,
-                      data_random_seed = 1,
-                      init_score = \"\",
-                      is_sparse = true,
-                      save_binary = false,
-                      categorical_feature = Int[],
-                      is_unbalance = false,
-                      metric = [\"l2\"],
-                      metric_freq = 1,
-                      is_training_metric = false,
-                      ndcg_at = Int[],
-                      num_machines = 1,
-                      local_listen_port = 12400,
-                      time_out = 120,
-                      machine_list_file = \"\",
-                     device_type=\"cpu\"])
+    LGBMRegression(; [
+        objective = "regression",
+        num_iterations = 10,
+        learning_rate = .1,
+        num_leaves = 127,
+        max_depth = -1,
+        tree_learner = \"serial\",
+        num_threads = Sys.CPU_THREADS,
+        histogram_pool_size = -1.,
+        min_data_in_leaf = 100,
+        min_sum_hessian_in_leaf = 10.,
+        lambda_l1 = 0.,
+        lambda_l2 = 0.,
+        min_gain_to_split = 0.,
+        feature_fraction = 1.,
+        feature_fraction_seed = 2,
+        bagging_fraction = 1.,
+        bagging_freq = 0,
+        bagging_seed = 3,
+        early_stopping_round = 0,
+        max_bin = 255,
+        data_random_seed = 1,
+        init_score = \"\",
+        is_sparse = true,
+        save_binary = false,
+        categorical_feature = Int[],
+        is_unbalance = false,
+        metric = [\"l2\"],
+        metric_freq = 1,
+        is_training_metric = false,
+        ndcg_at = Int[],
+        num_machines = 1,
+        local_listen_port = 12400,
+        time_out = 120,
+        machine_list_file = \"\",
+        device_type=\"cpu\",
+    ])
 
 Return a LGBMRegression estimator.
 """
-function LGBMRegression(; num_iterations = 10,
-                        learning_rate = .1,
-                        num_leaves = 127,
-                        max_depth = -1,
-                        tree_learner = "serial",
-                        num_threads = Sys.CPU_THREADS,
-                        histogram_pool_size = -1.,
-                        min_data_in_leaf = 100,
-                        min_sum_hessian_in_leaf = 10.,
-                        lambda_l1 = 0.,
-                        lambda_l2 = 0.,
-                        min_gain_to_split = 0.,
-                        feature_fraction = 1.,
-                        feature_fraction_seed = 2,
-                        bagging_fraction = 1.,
-                        bagging_freq = 0,
-                        bagging_seed = 3,
-                        early_stopping_round = 0,
-                        max_bin = 255,
-                        data_random_seed = 1,
-                        init_score = "",
-                        is_sparse = true,
-                        save_binary = false,
-                        categorical_feature = Int[],
-                        is_unbalance = false,
-                        metric = ["l2"],
-                        metric_freq = 1,
-                        is_training_metric = false,
-                        ndcg_at = Int[],
-                        num_machines = 1,
-                        local_listen_port = 12400,
-                        time_out = 120,
-                        machine_list_file = "",
-                        device_type="cpu")
+function LGBMRegression(;
+    objective = "regression",
+    num_iterations = 10,
+    learning_rate = .1,
+    num_leaves = 127,
+    max_depth = -1,
+    tree_learner = "serial",
+    num_threads = Sys.CPU_THREADS,
+    histogram_pool_size = -1.,
+    min_data_in_leaf = 100,
+    min_sum_hessian_in_leaf = 10.,
+    lambda_l1 = 0.,
+    lambda_l2 = 0.,
+    min_gain_to_split = 0.,
+    feature_fraction = 1.,
+    feature_fraction_seed = 2,
+    bagging_fraction = 1.,
+    bagging_freq = 0,
+    bagging_seed = 3,
+    early_stopping_round = 0,
+    max_bin = 255,
+    data_random_seed = 1,
+    init_score = "",
+    is_sparse = true,
+    save_binary = false,
+    categorical_feature = Int[],
+    is_unbalance = false,
+    metric = ["l2"],
+    metric_freq = 1,
+    is_training_metric = false,
+    ndcg_at = Int[],
+    num_machines = 1,
+    local_listen_port = 12400,
+    time_out = 120,
+    machine_list_file = "",
+    device_type="cpu",
+)
 
-    return LGBMRegression(Booster(), String[], "regression", num_iterations, learning_rate, num_leaves,
-                          max_depth, tree_learner, num_threads, histogram_pool_size,
-                          min_data_in_leaf, min_sum_hessian_in_leaf, lambda_l1, lambda_l2,
-                          min_gain_to_split, feature_fraction, feature_fraction_seed,
-                          bagging_fraction, bagging_freq, bagging_seed, early_stopping_round,
-                          max_bin, data_random_seed, init_score,
-                          is_sparse, save_binary, categorical_feature,
-                          is_unbalance, metric, metric_freq,
-                          is_training_metric, ndcg_at, num_machines, local_listen_port, time_out,
-                          machine_list_file, 1, device_type)
+    return LGBMRegression(
+        Booster(), String[], objective, num_iterations, learning_rate, num_leaves,
+        max_depth, tree_learner, num_threads, histogram_pool_size,
+        min_data_in_leaf, min_sum_hessian_in_leaf, lambda_l1, lambda_l2,
+        min_gain_to_split, feature_fraction, feature_fraction_seed,
+        bagging_fraction, bagging_freq, bagging_seed, early_stopping_round,
+        max_bin, data_random_seed, init_score,
+        is_sparse, save_binary, categorical_feature,
+        is_unbalance, metric, metric_freq,
+        is_training_metric, ndcg_at, num_machines, local_listen_port, time_out,
+        machine_list_file, 1, device_type
+    )
 end
 
-mutable struct LGBMBinary <: LGBMEstimator
-    booster::Booster
-    model::Vector{String}
-    application::String
 
-    num_iterations::Int
-    learning_rate::Float64
-    num_leaves::Int
-    max_depth::Int
-    tree_learner::String
-    num_threads::Int
-    histogram_pool_size::Float64
-
-    min_data_in_leaf::Int
-    min_sum_hessian_in_leaf::Float64
-    lambda_l1::Float64
-    lambda_l2::Float64
-    min_gain_to_split::Float64
-    feature_fraction::Float64
-    feature_fraction_seed::Int
-    bagging_fraction::Float64
-    bagging_freq::Int
-    bagging_seed::Int
-    early_stopping_round::Int
-
-    max_bin::Int
-    data_random_seed::Int
-    init_score::String
-    is_sparse::Bool
-    save_binary::Bool
-    categorical_feature::Vector{Int}
-
-    sigmoid::Float64
-    is_unbalance::Bool
-
-    metric::Vector{String}
-    metric_freq::Int
-    is_training_metric::Bool
-    ndcg_at::Vector{Int}
-
-    num_machines::Int
-    local_listen_port::Int
-    time_out::Int
-    machine_list_file::String
-
-    num_class::Int
-    device_type::String
-end
-
-"""
-    LGBMBinary(; [num_iterations = 10,
-                  learning_rate = .1,
-                  num_leaves = 127,
-                  max_depth = -1,
-                  tree_learner = \"serial\",
-                  num_threads = Sys.CPU_THREADS,
-                  histogram_pool_size = -1.,
-                  min_data_in_leaf = 100,
-                  min_sum_hessian_in_leaf = 10.,
-                  lambda_l1 = 0.,
-                  lambda_l2 = 0.,
-                  min_gain_to_split = 0.,
-                  feature_fraction = 1.,
-                  feature_fraction_seed = 2,
-                  bagging_fraction = 1.,
-                  bagging_freq = 0,
-                  bagging_seed = 3,
-                  early_stopping_round = 0,
-                  max_bin = 255,
-                  data_random_seed = 1,
-                  init_score = \"\",
-                  is_sparse = true,
-                  save_binary = false,
-                  categorical_feature = Int[],
-                  sigmoid = 1.,
-                  is_unbalance = false,
-                  metric = [\"binary_logloss\"],
-                  metric_freq = 1,
-                  is_training_metric = false,
-                  ndcg_at = Int[],
-                  num_machines = 1,
-                  local_listen_port = 12400,
-                  time_out = 120,
-                  machine_list_file = \"\",
-                  device_type=\"cpu\"])
-
-Return a LGBMBinary estimator.
-"""
-function LGBMBinary(; num_iterations = 10,
-                    learning_rate = .1,
-                    num_leaves = 127,
-                    max_depth = -1,
-                    tree_learner = "serial",
-                    num_threads = Sys.CPU_THREADS,
-                    histogram_pool_size = -1.,
-                    min_data_in_leaf = 100,
-                    min_sum_hessian_in_leaf = 10.,
-                    lambda_l1 = 0.,
-                    lambda_l2 = 0.,
-                    min_gain_to_split = 0.,
-                    feature_fraction = 1.,
-                    feature_fraction_seed = 2,
-                    bagging_fraction = 1.,
-                    bagging_freq = 0,
-                    bagging_seed = 3,
-                    early_stopping_round = 0,
-                    max_bin = 255,
-                    data_random_seed = 1,
-                    init_score = "",
-                    is_sparse = true,
-                    save_binary = false,
-                    categorical_feature = Int[],
-                    sigmoid = 1.,
-                    is_unbalance = false,
-                    metric = ["binary_logloss"],
-                    metric_freq = 1,
-                    is_training_metric = false,
-                    ndcg_at = Int[],
-                    num_machines = 1,
-                    local_listen_port = 12400,
-                    time_out = 120,
-                    machine_list_file = "",
-                    device_type="cpu"
-                    )
-
-    return LGBMBinary(Booster(), String[], "binary", num_iterations, learning_rate, num_leaves,
-                      max_depth, tree_learner, num_threads, histogram_pool_size, min_data_in_leaf,
-                      min_sum_hessian_in_leaf, lambda_l1, lambda_l2, min_gain_to_split,
-                      feature_fraction, feature_fraction_seed, bagging_fraction, bagging_freq,
-                      bagging_seed, early_stopping_round, max_bin, data_random_seed,
-                      init_score, is_sparse, save_binary,
-                      categorical_feature, sigmoid, is_unbalance, metric,
-                      metric_freq, is_training_metric, ndcg_at, num_machines, local_listen_port,
-                      time_out, machine_list_file, 1, device_type)
-end
-
-mutable struct LGBMMulticlass <: LGBMEstimator
+mutable struct LGBMClassification <: LGBMEstimator
     booster::Booster
     model::Vector{String}
     application::String
@@ -320,88 +193,96 @@ mutable struct LGBMMulticlass <: LGBMEstimator
 end
 
 """
-    LGBMMulticlass(; [num_iterations = 10,
-                      learning_rate = .1,
-                      num_leaves = 127,
-                      max_depth = -1,
-                      tree_learner = \"serial\",
-                      num_threads = Sys.CPU_THREADS,
-                      histogram_pool_size = -1.,
-                      min_data_in_leaf = 100,
-                      min_sum_hessian_in_leaf = 10.,
-                      lambda_l1 = 0.,
-                      lambda_l2 = 0.,
-                      min_gain_to_split = 0.,
-                      feature_fraction = 1.,
-                      feature_fraction_seed = 2,
-                      bagging_fraction = 1.,
-                      bagging_freq = 0,
-                      bagging_seed = 3,
-                      early_stopping_round = 0,
-                      max_bin = 255,
-                      data_random_seed = 1,
-                      init_score = \"\",
-                      is_sparse = true,
-                      save_binary = false,
-                      categorical_feature = Int[],
-                      is_unbalance = false,
-                      metric = [\"multi_logloss\"],
-                      metric_freq = 1,
-                      is_training_metric = false,
-                      ndcg_at = Int[],
-                      num_machines = 1,
-                      local_listen_port = 12400,
-                      time_out = 120,
-                      machine_list_file = \"\",
-                      num_class = 1,
-                      device_type=\"cpu\"])
+    LGBMClassification(;[
+        objective = "multiclass",
+        num_iterations = 10,
+        learning_rate = .1,
+        num_leaves = 127,
+        max_depth = -1,
+        tree_learner = \"serial\",
+        num_threads = Sys.CPU_THREADS,
+        histogram_pool_size = -1.,
+        min_data_in_leaf = 100,
+        min_sum_hessian_in_leaf = 10.,
+        lambda_l1 = 0.,
+        lambda_l2 = 0.,
+        min_gain_to_split = 0.,
+        feature_fraction = 1.,
+        feature_fraction_seed = 2,
+        bagging_fraction = 1.,
+        bagging_freq = 0,
+        bagging_seed = 3,
+        early_stopping_round = 0,
+        max_bin = 255,
+        data_random_seed = 1,
+        init_score = \"\",
+        is_sparse = true,
+        save_binary = false,
+        categorical_feature = Int[],
+        is_unbalance = false,
+        metric = [\"multi_logloss\"],
+        metric_freq = 1,
+        is_training_metric = false,
+        ndcg_at = Int[],
+        num_machines = 1,
+        local_listen_port = 12400,
+        time_out = 120,
+        machine_list_file = \"\",
+        num_class = 1,
+        device_type=\"cpu\",
+    ])
 
-Return a LGBMMulticlass estimator.
+Return a LGBMClassification estimator.
 """
-function LGBMMulticlass(; num_iterations = 10,
-                        learning_rate = .1,
-                        num_leaves = 127,
-                        max_depth = -1,
-                        tree_learner = "serial",
-                        num_threads = Sys.CPU_THREADS,
-                        histogram_pool_size = -1.,
-                        min_data_in_leaf = 100,
-                        min_sum_hessian_in_leaf = 10.,
-                        lambda_l1 = 0.,
-                        lambda_l2 = 0.,
-                        min_gain_to_split = 0.,
-                        feature_fraction = 1.,
-                        feature_fraction_seed = 2,
-                        bagging_fraction = 1.,
-                        bagging_freq = 0,
-                        bagging_seed = 3,
-                        early_stopping_round = 0,
-                        max_bin = 255,
-                        data_random_seed = 1,
-                        init_score = "",
-                        is_sparse = true,
-                        save_binary = false,
-                        categorical_feature = Int[],
-                        is_unbalance = false,
-                        metric = ["multi_logloss"],
-                        metric_freq = 1,
-                        is_training_metric = false,
-                        ndcg_at = Int[],
-                        num_machines = 1,
-                        local_listen_port = 12400,
-                        time_out = 120,
-                        machine_list_file = "",
-                        num_class = 1,
-                        device_type="cpu")
+function LGBMClassification(;
+    objective = "multiclass",
+    num_iterations = 10,
+    learning_rate = .1,
+    num_leaves = 127,
+    max_depth = -1,
+    tree_learner = "serial",
+    num_threads = Sys.CPU_THREADS,
+    histogram_pool_size = -1.,
+    min_data_in_leaf = 100,
+    min_sum_hessian_in_leaf = 10.,
+    lambda_l1 = 0.,
+    lambda_l2 = 0.,
+    min_gain_to_split = 0.,
+    feature_fraction = 1.,
+    feature_fraction_seed = 2,
+    bagging_fraction = 1.,
+    bagging_freq = 0,
+    bagging_seed = 3,
+    early_stopping_round = 0,
+    max_bin = 255,
+    data_random_seed = 1,
+    init_score = "",
+    is_sparse = true,
+    save_binary = false,
+    categorical_feature = Int[],
+    is_unbalance = false,
+    metric = ["None"],
+    metric_freq = 1,
+    is_training_metric = false,
+    ndcg_at = Int[],
+    num_machines = 1,
+    local_listen_port = 12400,
+    time_out = 120,
+    machine_list_file = "",
+    num_class = 2,
+    device_type="cpu",
+)
 
-    return LGBMMulticlass(Booster(), String[], "multiclass", num_iterations, learning_rate,
-                          num_leaves, max_depth, tree_learner, num_threads, histogram_pool_size,
-                          min_data_in_leaf, min_sum_hessian_in_leaf, lambda_l1, lambda_l2,
-                          min_gain_to_split, feature_fraction, feature_fraction_seed,
-                          bagging_fraction, bagging_freq, bagging_seed, early_stopping_round,
-                          max_bin, data_random_seed, init_score,
-                          is_sparse, save_binary, categorical_feature,
-                          is_unbalance, metric, metric_freq,
-                          is_training_metric, ndcg_at, num_machines, local_listen_port, time_out,
-                          machine_list_file, num_class, device_type)
+    return LGBMClassification(
+        Booster(), String[], objective, num_iterations, learning_rate,
+        num_leaves, max_depth, tree_learner, num_threads, histogram_pool_size,
+        min_data_in_leaf, min_sum_hessian_in_leaf, lambda_l1, lambda_l2,
+        min_gain_to_split, feature_fraction, feature_fraction_seed,
+        bagging_fraction, bagging_freq, bagging_seed, early_stopping_round,
+        max_bin, data_random_seed, init_score,
+        is_sparse, save_binary, categorical_feature,
+        is_unbalance, metric, metric_freq,
+        is_training_metric, ndcg_at, num_machines, local_listen_port, time_out,
+        machine_list_file, num_class, device_type,
+    )
 end

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -131,7 +131,7 @@ function LGBMRegression(; num_iterations = 10,
                           is_sparse, save_binary, categorical_feature,
                           is_unbalance, metric, metric_freq,
                           is_training_metric, ndcg_at, num_machines, local_listen_port, time_out,
-                          machine_list_file,1,device_type)
+                          machine_list_file, 1, device_type)
 end
 
 mutable struct LGBMBinary <: LGBMEstimator
@@ -267,7 +267,7 @@ function LGBMBinary(; num_iterations = 10,
                       init_score, is_sparse, save_binary,
                       categorical_feature, sigmoid, is_unbalance, metric,
                       metric_freq, is_training_metric, ndcg_at, num_machines, local_listen_port,
-                      time_out, machine_list_file, 1,device_type)
+                      time_out, machine_list_file, 1, device_type)
 end
 
 mutable struct LGBMMulticlass <: LGBMEstimator
@@ -403,5 +403,5 @@ function LGBMMulticlass(; num_iterations = 10,
                           is_sparse, save_binary, categorical_feature,
                           is_unbalance, metric, metric_freq,
                           is_training_metric, ndcg_at, num_machines, local_listen_port, time_out,
-                          machine_list_file, num_class,device_type)
+                          machine_list_file, num_class, device_type)
 end

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -1,5 +1,5 @@
 """
-    fit(estimator, X, y[, test...]; [verbosity = 1, is_row_major = false])
+    fit!(estimator, X, y[, test...]; [verbosity = 1, is_row_major = false])
 
 Fit the `estimator` with features data `X` and label `y` using the X-y pairs in `test` as
 validation sets.
@@ -21,7 +21,7 @@ array that holds the validation metric's value at each iteration.
 * `weights::Vector{Tw<:Real}`: the training weights.
 * `init_score::Vector{Ti<:Real}`: the init scores.
 """
-function fit(estimator::LGBMEstimator, X::Matrix{TX},
+function fit!(estimator::LGBMEstimator, X::Matrix{TX},
     y::Vector{Ty}, test::Tuple{Matrix{TX},Vector{Ty}}...; verbosity::Integer = 1,
     is_row_major = false, weights::Vector{Tw} = Vector{Float32}(),
     init_score::Vector{Ti} = Vector{Float64}()) where {TX<:Real,Ty<:Real,Tw<:Real,Ti<:Real}
@@ -57,13 +57,13 @@ function fit(estimator::LGBMEstimator, X::Matrix{TX},
     end
 
     log_debug(verbosity, "Started training...\n")
-    results = train(estimator, tests_names, verbosity, start_time)
+    results = train!(estimator, tests_names, verbosity, start_time)
     # estimator.model = readlines("$(tempdir)/model.txt")
 
     return results
 end
 
-function train(estimator::LGBMEstimator, tests_names::Vector{String}, verbosity::Integer,
+function train!(estimator::LGBMEstimator, tests_names::Vector{String}, verbosity::Integer,
                start_time::DateTime)
     results = Dict{String,Dict{String,Vector{Float64}}}()
     n_tests = length(tests_names)

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -3,7 +3,8 @@
     predict(estimator, X; [predict_type = 0, num_iterations = -1, verbosity = 1,
     is_row_major = false])
 
-Return an array with the labels that the `estimator` predicts for features data `X`.
+Return a **MATRIX** with the labels that the `estimator` predicts for features data `X`.
+Use `dropdims` if a vector is required.
 
 # Arguments
 * `estimator::LGBMEstimator`: the estimator to use in the prediction.
@@ -21,7 +22,7 @@ function predict(
     estimator::LGBMEstimator, X::AbstractMatrix{TX}; predict_type::Integer = 0,
     num_iterations::Integer = -1, verbosity::Integer = 1,
     is_row_major::Bool = false,
-) where TX<:Real
+) where TX <:Real
 
     @assert(estimator.booster.handle != C_NULL, "Estimator does not contain a fitted model.")
 
@@ -31,8 +32,9 @@ function predict(
         estimator.booster, X, predict_type, num_iterations, is_row_major
     )
 
-    # This works the same one way or another because when n=1, reshaping is basically no-op
-    prediction = prediction_reshaper(estimator, prediction)
+    # This works the same one way or another because when n=1, (regression) reshaping is basically no-op
+    # except for adding the extra dim
+    prediction = transpose(reshape(prediction, estimator.num_class, :))
 
     return prediction
 
@@ -40,10 +42,10 @@ end
 
 
 function predict_classes(
-    estimator::LGBMMulticlass, X::AbstractMatrix{TX}; predict_type::Integer = 0,
+    estimator::LGBMClassification, X::AbstractMatrix{TX}; predict_type::Integer = 0,
     num_iterations::Integer = -1, verbosity::Integer = 1,
-    is_row_major::Bool = false,
-) where TX<:Real
+    is_row_major::Bool = false, binary_threshold::Float64 = 0.5
+) where TX <:Real
 
     # pass through, get probabilities
     predicted_probabilities = predict(
@@ -51,16 +53,11 @@ function predict_classes(
         verbosity=verbosity, is_row_major=is_row_major,
     )
 
+    # binary case
+    if estimator.num_class == 1
+        return Int.(predicted_probabilities .> binary_threshold)
+    end
+
     return getindex.(argmax(predicted_probabilities, dims=2), 2) .- 1
 
 end
-
-
-@inline function prediction_reshaper(estimator::LGBMMulticlass, prediction::AbstractVector{Float64})
-
-    num_classes = estimator.num_class
-    return transpose(reshape(prediction, num_classes, :))
-
-end
-@inline prediction_reshaper(estimator::LGBMEstimator, prediction::AbstractVector{Float64}) = prediction
-

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -22,7 +22,7 @@ function predict(
     estimator::LGBMEstimator, X::AbstractMatrix{TX}; predict_type::Integer = 0,
     num_iterations::Integer = -1, verbosity::Integer = 1,
     is_row_major::Bool = false,
-) where TX <:Real
+)::Matrix{Float64} where TX <:Real
 
     @assert(estimator.booster.handle != C_NULL, "Estimator does not contain a fitted model.")
 

--- a/test/initScoreTest.jl
+++ b/test/initScoreTest.jl
@@ -42,8 +42,8 @@ using LightGBM
             max_depth = -1,
         )
 
-        LightGBM.fit(estimator, X_train, y_train, verbosity = -1, init_score=regression_train_init);
-        LightGBM.fit(estimator, X_train, y_train, (X_test, y_test), verbosity = -1, init_score=regression_train_init);
+        LightGBM.fit!(estimator, X_train, y_train, verbosity = -1, init_score=regression_train_init);
+        LightGBM.fit!(estimator, X_train, y_train, (X_test, y_test), verbosity = -1, init_score=regression_train_init);
         @test true
     catch
         @test false

--- a/test/mlj/binary_classifier.jl
+++ b/test/mlj/binary_classifier.jl
@@ -10,7 +10,7 @@ import LightGBM
 
 ## CLASSIFIER -- shamelessly copied from MLJModels/test/XGBoost.jl
 
-model = LightGBM.MLJInterface.LGBMBinary(num_iterations=100)
+model = LightGBM.MLJInterface.LGBMClassifier(objective="binary", num_iterations=100)
 
 # test binary case:
 N = 2
@@ -46,7 +46,7 @@ misclassification_rate   = sum(yhat .!= y[test])/length(test)
 @test isa(report, Tuple)
 
 expected_return_type = Tuple{
-    LightGBM.LGBMBinary,
+    LightGBM.LGBMClassification,
     CategoricalArrays.CategoricalArray,
 }
 
@@ -55,7 +55,7 @@ expected_return_type = Tuple{
 # here we test the bit where we try to fit a nonbinary using a binary estimator -- we expect this to throw
 crazyN = 5 # testing nonbinary
 ycrazy = string.(mod.(round.(Int, X.x1 * 10), crazyN)) |> MLJBase.categorical
-@test_throws ErrorException MLJBase.fit(model, 0, X, ycrazy)
+@test_throws ArgumentError MLJBase.fit(model, 0, X, ycrazy)
 
 end # module
 true

--- a/test/mlj/multiclass_classifier.jl
+++ b/test/mlj/multiclass_classifier.jl
@@ -45,7 +45,7 @@ misclassification_rate   = sum(yhat .!= y[test])/length(test)
 @test isa(report, Tuple)
 
 expected_return_type = Tuple{
-    LightGBM.LGBMMulticlass,
+    LightGBM.LGBMClassification,
     CategoricalArrays.CategoricalArray,
 }
 

--- a/test/mlj/multiclass_classifier.jl
+++ b/test/mlj/multiclass_classifier.jl
@@ -15,7 +15,7 @@ N = 5
 Nsamples = 3000
 seed!(0)
 
-model = LightGBM.MLJInterface.LGBMClassifier(num_iterations=100, num_class=N)
+model = LightGBM.MLJInterface.LGBMClassifier(num_iterations=100)
 
 X       = (x1=rand(Nsamples), x2=rand(Nsamples), x3=rand(Nsamples))
 ycat    = string.(mod.(round.(Int, X.x1 * 10), N)) |> MLJBase.categorical
@@ -50,10 +50,6 @@ expected_return_type = Tuple{
 }
 
 @test isa(fitresult, expected_return_type)
-
-# here we test the bit where we try to fit a single class problem -- we expect this to throw
-model = LightGBM.MLJInterface.LGBMClassifier(num_iterations=100, num_class=1)
-@test_throws ErrorException MLJBase.fit(model, 0, X, y)
 
 end # module
 true

--- a/test/mlj/regression.jl
+++ b/test/mlj/regression.jl
@@ -13,7 +13,7 @@ Nsamples = 3000
 seed!(0)
 calc_rmse(p, t) = sqrt(sum((p - t) .^ 2) / length(p))
 
-model = LightGBM.MLJInterface.LGBMRegression(num_iterations=100)
+model = LightGBM.MLJInterface.LGBMRegressor(num_iterations=100)
 
 X       = rand(Nsamples, 5)
 y       = sqrt.(sum(X .^ 2, dims=2)) # make the targets the L2 norm of the vectors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,11 +20,11 @@ end
         include(joinpath("mlj", "binary_classifier.jl"))
     end
 
-    @testset "Binary LightGBM" begin
+    @testset "Multiclass LightGBM" begin
         include(joinpath("mlj", "multiclass_classifier.jl"))
     end
 
-    @testset "Binary LightGBM" begin
+    @testset "Regression LightGBM" begin
         include(joinpath("mlj", "regression.jl"))
     end
 

--- a/test/weightsTest.jl
+++ b/test/weightsTest.jl
@@ -23,7 +23,9 @@ using LightGBM
         binary_train_weight = readdlm(joinpath(LGBM_PATH, "examples", "binary_classification", "binary.train.weight"), '\t')[:,1]
 
         # Test binary estimator.
-        estimator = LightGBM.LGBMBinary(
+        estimator = LightGBM.LGBMClassification(
+            objective = "binary",
+            num_class = 1,
             num_iterations = 20,
             learning_rate = .1,
             early_stopping_round = 1,
@@ -39,8 +41,8 @@ using LightGBM
         )
 
         # Test fitting.
-        LightGBM.fit(estimator, X_train, y_train, verbosity = -1, weights=binary_train_weight[:,1])
-        LightGBM.fit(estimator, X_train, y_train, (X_test, y_test), verbosity = -1, weights=binary_train_weight[:,1])
+        LightGBM.fit!(estimator, X_train, y_train, verbosity = -1, weights=binary_train_weight[:,1])
+        LightGBM.fit!(estimator, X_train, y_train, (X_test, y_test), verbosity = -1, weights=binary_train_weight[:,1])
 
         @test true
     catch


### PR DESCRIPTION
Upgrade to StatsBase

num_class is now auto-filled by MLJ interface and not accepted as a parameter

Dictinction between binary/multiclass is removed (both MLJ and entire codebase)

User can now pass an objective. MLJ interface only checks that an objective is either a valid classification or regression objective.
