### PR TITLE
Save model to string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         version: ['1.0', '1.1', '1.2', '1.3']
         os:  [windows-latest, ubuntu-latest, macOS-latest]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.0', '1.1', '1.2', '1.3']
+        version: ['1.0', '1.1', '1.2', '1.3', '1.4']
         os:  [windows-latest, ubuntu-latest, macOS-latest]
         #os: [ubuntu-latest] # temporarily restrict to linux only
         arch:

--- a/src/LightGBM.jl
+++ b/src/LightGBM.jl
@@ -2,6 +2,7 @@ module LightGBM
 
 using Dates
 
+import Base
 import Libdl
 import StatsBase
 

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -3,7 +3,7 @@ abstract type LGBMEstimator <: Estimator end
 
 mutable struct LGBMRegression <: LGBMEstimator
     booster::Booster
-    model::Vector{String}
+    model::String
     application::String
 
     num_iterations::Int
@@ -129,7 +129,7 @@ function LGBMRegression(;
 )
 
     return LGBMRegression(
-        Booster(), String[], objective, num_iterations, learning_rate, num_leaves,
+        Booster(), "", objective, num_iterations, learning_rate, num_leaves,
         max_depth, tree_learner, num_threads, histogram_pool_size,
         min_data_in_leaf, min_sum_hessian_in_leaf, lambda_l1, lambda_l2,
         min_gain_to_split, feature_fraction, feature_fraction_seed,
@@ -145,7 +145,7 @@ end
 
 mutable struct LGBMClassification <: LGBMEstimator
     booster::Booster
-    model::Vector{String}
+    model::String
     application::String
 
     num_iterations::Int
@@ -274,7 +274,7 @@ function LGBMClassification(;
 )
 
     return LGBMClassification(
-        Booster(), String[], objective, num_iterations, learning_rate,
+        Booster(), "", objective, num_iterations, learning_rate,
         num_leaves, max_depth, tree_learner, num_threads, histogram_pool_size,
         min_data_in_leaf, min_sum_hessian_in_leaf, lambda_l1, lambda_l2,
         min_gain_to_split, feature_fraction, feature_fraction_seed,

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -58,7 +58,6 @@ function fit!(estimator::LGBMEstimator, X::Matrix{TX},
 
     log_debug(verbosity, "Started training...\n")
     results = train!(estimator, tests_names, verbosity, start_time)
-    # estimator.model = readlines("$(tempdir)/model.txt")
 
     return results
 end
@@ -85,8 +84,16 @@ function train!(estimator::LGBMEstimator, tests_names::Vector{String}, verbosity
             log_info(verbosity, "Stopped training because there are no more leaves that meet the ",
                      "split requirements.")
         end
-        is_finished == 1 && return results
+        if is_finished == 1
+            # save the model in serialised form, in case we should be deepcopied or serialised elsewhere
+            estimator.model = LGBM_BoosterSaveModelToString(estimator.booster, 0, 0)
+            return results
+        end
     end
+
+    # save the model in serialised form, in case we should be deepcopied or serialised elsewhere
+    estimator.model = LGBM_BoosterSaveModelToString(estimator.booster, 0, 0)
+
     return results
 end
 

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -524,7 +524,7 @@ end
 
 function LGBM_BoosterSaveModelToString(bst::Booster, start_iteration::Integer, num_iteration::Integer)::String
 
-    # places forthe call to write to
+    # places for the call to write to
     out_len = Ref{Int64}()
     out_str = Vector{UInt8}(undef, 2)
     buffer_len = Int64(1)

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -108,6 +108,21 @@ LGBM_PATH = if isabspath(LGBM_PATH) LGBM_PATH else abspath(joinpath(pwd(), "..",
 
     @test isapprox(pre, post, rtol=1e-16)
 
+    # test making copy of estimator
+    copy_estimator = deepcopy(estimator)
+    @test copy_estimator.booster.handle != estimator.booster.handle
+
+    # check that deepcopy predictions are equivalent
+    copy_pre_preds = LightGBM.predict(copy_estimator, X_train, verbosity = -1)
+    @test isapprox(copy_pre_preds, pre, rtol=1e-16)
+
+    # test reload upon predict works if we have a null handle
+    LightGBM.LGBM_BoosterFree(copy_estimator.booster)
+    copy_preds = LightGBM.predict(copy_estimator, X_train, verbosity = -1)
+
+    @test isapprox(copy_pre_preds, copy_preds, rtol=1e-16)
+    @test isapprox(pre, copy_preds, rtol=1e-16)
+
     # Test cross-validation.
     splits = (collect(1:3500), collect(3501:7000))
     LightGBM.cv(estimator, X_train, y_train, splits; verbosity = -1)

--- a/test/ffi/base_utils.jl
+++ b/test/ffi/base_utils.jl
@@ -1,0 +1,24 @@
+module TestBaseUtils
+
+using LightGBM
+using Test
+
+@testset "deepcopy: Booster" begin
+
+    b = LightGBM.LGBM_BoosterCreateFromModelfile(joinpath(@__DIR__, "data", "test_tree"))
+    bb = deepcopy(b)
+
+    @test b != bb
+    @test b !== bb
+    @test LightGBM.LGBM_BoosterSaveModelToString(b, 0, 0) == LightGBM.LGBM_BoosterSaveModelToString(bb, 0, 0)
+
+    # test for empty boosters too
+    b_empty = LightGBM.Booster()
+    bb_empty = deepcopy(b_empty)
+
+    @test b_empty != bb_empty
+    @test b_empty !== bb_empty
+
+end
+
+end # module

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -292,4 +292,23 @@ end
 end
 
 
+@testset "LGBM_BoosterSaveModelToString" begin
+
+    booster = LightGBM.LGBM_BoosterCreateFromModelfile(joinpath(@__DIR__, "data", "test_tree"))
+    string_repr = LightGBM.LGBM_BoosterSaveModelToString(booster, 0, 0)
+    # so it turns out that the string save and file save aren't necesarily the same so..
+    # check a bunch of expected substrings, etc
+    @test occursin("version=v3", string_repr)
+    @test occursin("num_leaves=1", string_repr)
+    @test occursin("end of trees", string_repr)
+    @test occursin("feature importances:", string_repr)
+    @test occursin("parameters:", string_repr)
+    @test occursin("[convert_model: gbdt_prediction.cpp]", string_repr)
+    @test occursin("Tree=0", string_repr)
+    @test occursin("end of parameters", string_repr)
+
+
+end
+
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,10 @@ using Test
         include(joinpath("ffi", "booster.jl"))
     end
 
+    @testset "Base Utils" begin
+        include(joinpath("ffi", "base_utils.jl"))
+    end
+
 end
 
 @testset "MLJ interface tests" begin


### PR DESCRIPTION
I noticed that passing pointers around is multiprocessing and deepcopy unsafe, so this to implement in-memory serialisation

- Implemented `LGBM_BoosterSaveModelToString` C-API
- Implemented `deepcopy_internal` for `LightGBM.Booster` object, which uses the above to serialise and then reload a new booster from the serialised form
- Implemented that fitting will store the serialised model, so that `predict` will load from the serialised model if the booster happens to be C_NULL (which seems likely from usage of serialise for IPC etc, where pointers are always set to C_NULL, andrightly so)
- Added tests
- Updated Github CI matrix to turn off fail-fast