### PR TITLE
Mlj update method

### DIFF
--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -189,6 +189,15 @@ function update(mlj_model::MLJInterface.MODELS, verbosity::Int, fitresult, cache
     end
 
     additional_iterations = mlj_model.num_iterations - old_mlj_model.num_iterations
+
+    if additional_iterations < 0
+        # less iterations isn't very valid so re-fit from scratch
+        # TODO: I think theres a LightGBM API where you can prune
+        # the boosting, so we would just do that instead of wasting time re-fitting
+        # although we'd still have to consider fit-report etc
+        return MLJInterface.fit(mlj_model, verbosity, X, y, w)
+    end
+
     if verbosity >= 1
         @info("Not refitting from scratch", additional_iterations)
     end

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -174,8 +174,6 @@ function fit(mlj_model::MODELS, verbosity::Int, X, y, w=Vector{AbstractFloat}())
     cache = nothing
     report = (report,)
 
-    # Caution: The model is a pointer to a memory location including its training data
-    # This definitely needs fixing
     return (model, cache, report)
 
 end

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -183,7 +183,7 @@ function update(mlj_model::MLJInterface.MODELS, verbosity::Int, fitresult, cache
     old_lgbm_model, old_classes, old_mlj_model = fitresult
 
     # we can continue boosting if and only if num_iterations has changed
-    if MLJModelInterface.is_same_except(old_model, mode, :num_iterations)
+    if MLJModelInterface.is_same_except(old_mlj_model, mlj_model, :num_iterations)
         additional_iterations = mlj_model.num_iterations - old_mlj_model.num_iterations
         # eh this is ugly, possibly prompts a need for some refactoring
         report = LightGBM.train!(old_lgbm_model, additional_iterations, String[], verbosity, LightGBM.Dates.now())

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -189,7 +189,7 @@ function update(mlj_model::MLJInterface.MODELS, verbosity::Int, fitresult, cache
         report = LightGBM.train!(old_lgbm_model, additional_iterations, String[], verbosity, LightGBM.Dates.now())
         # should probably dump report too, its just an empty dict...
         fitresult = (old_lgbm_model, old_classes, mlj_model)
-        return (fitresult, cache, report)
+        return (fitresult, cache, (report,))
     end
 
     # if we get here it's just means we need to call fit directly

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -1,4 +1,5 @@
 """
+    fit!(estimator, num_iterations, X, y[, test...]; [verbosity = 1, is_row_major = false])
     fit!(estimator, X, y[, test...]; [verbosity = 1, is_row_major = false])
 
 Fit the `estimator` with features data `X` and label `y` using the X-y pairs in `test` as
@@ -10,6 +11,7 @@ array that holds the validation metric's value at each iteration.
 
 # Arguments
 * `estimator::LGBMEstimator`: the estimator to be fit.
+* `num_iterations::Int`: OPTIONAL -- defaults to estimator.num_iterations if not provided
 * `X::Matrix{TX<:Real}`: the features data.
 * `y::Vector{Ty<:Real}`: the labels.
 * `test::Tuple{Matrix{TX},Vector{Ty}}...`: optionally contains one or more tuples of X-y pairs of
@@ -21,10 +23,13 @@ array that holds the validation metric's value at each iteration.
 * `weights::Vector{Tw<:Real}`: the training weights.
 * `init_score::Vector{Ti<:Real}`: the init scores.
 """
-function fit!(estimator::LGBMEstimator, X::Matrix{TX},
-    y::Vector{Ty}, test::Tuple{Matrix{TX},Vector{Ty}}...; verbosity::Integer = 1,
-    is_row_major = false, weights::Vector{Tw} = Vector{Float32}(),
-    init_score::Vector{Ti} = Vector{Float64}()) where {TX<:Real,Ty<:Real,Tw<:Real,Ti<:Real}
+function fit!(
+    estimator::LGBMEstimator, num_iterations::Int, X::Matrix{TX}, y::Vector{Ty}, test::Tuple{Matrix{TX},Vector{Ty}}...;
+    verbosity::Integer = 1,
+    is_row_major = false,
+    weights::Vector{Tw} = Vector{Float32}(),
+    init_score::Vector{Ti} = Vector{Float64}(),
+) where {TX<:Real,Ty<:Real,Tw<:Real,Ti<:Real}
 
     start_time = now()
 
@@ -61,9 +66,13 @@ function fit!(estimator::LGBMEstimator, X::Matrix{TX},
 
     return results
 end
+# Old signature, pass through args
+fit!(estimator, X, y, test...; kwargs...) = fit!(estimator, estimator.num_iterations, X, y, test...; kwargs...)
 
-function train!(estimator::LGBMEstimator, tests_names::Vector{String}, verbosity::Integer,
-               start_time::DateTime)
+
+function train!(
+    estimator::LGBMEstimator, num_iterations::Int, tests_names::Vector{String}, verbosity::Integer, start_time::DateTime
+)
     results = Dict{String,Dict{String,Vector{Float64}}}()
     n_tests = length(tests_names)
     metrics = LGBM_BoosterGetEvalNames(estimator.booster)
@@ -96,6 +105,8 @@ function train!(estimator::LGBMEstimator, tests_names::Vector{String}, verbosity
 
     return results
 end
+# Old signature, pas through args
+train!(estimator, tests_names, verbosity, start_time) = train!(estimator, estimator.num_iterations, tests_names, verbosity, start_time)
 
 function eval_metrics!(results::Dict{String,Dict{String,Vector{Float64}}},
                        estimator::LGBMEstimator, tests_names::Vector{String}, iter::Integer,
@@ -139,6 +150,7 @@ function eval_metrics!(results::Dict{String,Dict{String,Vector{Float64}}},
     return 0
 end
 
+
 function store_scores!(results::Dict{String,Dict{String,Vector{Float64}}},
                        estimator::LGBMEstimator, iter::Integer, evalname::String,
                        scores::Vector{Cdouble}, metrics::Vector{String})
@@ -158,6 +170,7 @@ function store_scores!(results::Dict{String,Dict{String,Vector{Float64}}},
     return nothing
 end
 
+
 function print_scores(estimator::LGBMEstimator, iter::Integer, name::String, n_metrics::Integer,
                       scores::Vector{Cdouble}, metrics::Vector{String}, verbosity::Integer)
     log_info(verbosity, "Iteration: ", iter, ", ", name, "'s ")
@@ -167,6 +180,7 @@ function print_scores(estimator::LGBMEstimator, iter::Integer, name::String, n_m
     end
     log_info(verbosity, "\n")
 end
+
 
 function stringifyparams(estimator::LGBMEstimator, params::Vector{Symbol})
     paramstring = ""

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -27,8 +27,8 @@ function fit!(
     estimator::LGBMEstimator, num_iterations::Int, X::Matrix{TX}, y::Vector{Ty}, test::Tuple{Matrix{TX},Vector{Ty}}...;
     verbosity::Integer = 1,
     is_row_major = false,
-    weights::Vector{Tw} = Vector{Float32}(),
-    init_score::Vector{Ti} = Vector{Float64}(),
+    weights::Vector{Tw} = Float32[],
+    init_score::Vector{Ti} = Float64[],
 ) where {TX<:Real,Ty<:Real,Tw<:Real,Ti<:Real}
 
     start_time = now()

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -81,7 +81,10 @@ function train!(
     best_score = fill(-Inf, (n_metrics, n_tests))
     best_iter = fill(1, (n_metrics, n_tests))
 
-    for iter in 1:estimator.num_iterations
+    start_iter = get_iter_number(estimator) + 1
+    end_iter = start_iter + num_iterations - 1
+
+    for iter in start_iter:end_iter
         is_finished = LGBM_BoosterUpdateOneIter(estimator.booster)
         log_debug(verbosity, Dates.CompoundPeriod(now() - start_time),
                   " elapsed, finished iteration ", iter, "\n")
@@ -94,9 +97,7 @@ function train!(
                      "split requirements.")
         end
         if is_finished == 1
-            # save the model in serialised form, in case we should be deepcopied or serialised elsewhere
-            estimator.model = LGBM_BoosterSaveModelToString(estimator.booster, 0, 0)
-            return results
+            break
         end
     end
 
@@ -105,8 +106,9 @@ function train!(
 
     return results
 end
-# Old signature, pas through args
+# Old signature, pass through args
 train!(estimator, tests_names, verbosity, start_time) = train!(estimator, estimator.num_iterations, tests_names, verbosity, start_time)
+
 
 function eval_metrics!(results::Dict{String,Dict{String,Vector{Float64}}},
                        estimator::LGBMEstimator, tests_names::Vector{String}, iter::Integer,

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -62,16 +62,3 @@ function predict_classes(
 
 end
 
-function tryload!(estimator::LGBMEstimator)
-
-    if estimator.booster.handle == C_NULL
-        # first check for a serialised model
-        if length(estimator.model) == 0
-            throw(ErrorException("Estimator does not contain a fitted model."))
-        end
-        # load it
-        estimator.booster = LGBM_BoosterLoadModelFromString(estimator.model)
-    end
-
-    return nothing
-end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -93,7 +93,6 @@ function get_iter_number(estimator::LGBMEstimator)
         throw(ErrorException("Estimator does not contain any form of booster"))
     end
 
-    # we add plus 1 to be julia indexing friendly
     return LGBM_BoosterGetCurrentIteration(estimator.booster)
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -69,3 +69,32 @@ function shrinkresults!(results, last_retained_iter::Integer)
     end
     return nothing
 end
+
+
+function tryload!(estimator::LGBMEstimator)
+
+    if estimator.booster.handle == C_NULL
+        # first check for a serialised model
+        if length(estimator.model) == 0
+            throw(ErrorException("Estimator does not contain a fitted model."))
+        end
+        # load it
+        estimator.booster = LGBM_BoosterLoadModelFromString(estimator.model)
+    end
+
+    return nothing
+end
+
+
+function get_iter_number(estimator::LGBMEstimator)
+
+    if estimator.booster.handle == C_NULL
+        # We cannot call LGBM_BoosterGetCurrentIteration without an initialised booster
+        throw(ErrorException("Estimator does not contain any form of booster"))
+    end
+
+    # we add plus 1 to be julia indexing friendly
+    return LGBM_BoosterGetCurrentIteration(estimator.booster)
+
+end
+

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ const BOOSTERPARAMS = [:application, :learning_rate, :num_leaves, :max_depth, :t
                        :feature_fraction, :feature_fraction_seed, :bagging_fraction,
                        :bagging_freq, :bagging_seed, :early_stopping_round, :sigmoid,
                        :is_unbalance, :metric, :is_training_metric, :ndcg_at, :num_machines,
-                       :local_listen_port, :time_out, :machine_list_file, :num_class,:device]
+                       :local_listen_port, :time_out, :machine_list_file, :num_class, :device_type]
 
 const INDEXPARAMS = [:categorical_feature]
 

--- a/test/mlj/binary_classifier.jl
+++ b/test/mlj/binary_classifier.jl
@@ -48,6 +48,7 @@ misclassification_rate   = sum(yhat .!= y[test])/length(test)
 expected_return_type = Tuple{
     LightGBM.LGBMClassification,
     CategoricalArrays.CategoricalArray,
+    LightGBM.MLJInterface.LGBMClassifier,
 }
 
 @test isa(fitresult, expected_return_type)

--- a/test/mlj/binary_classifier.jl
+++ b/test/mlj/binary_classifier.jl
@@ -40,8 +40,9 @@ misclassification_rate   = sum(yhat .!= y[test])/length(test)
 # All we can really say about fitting with/without weights for this example is that the solutions shouldn't be identical
 @test yhat_with_weights != yhat
 
-# It's what it should be for now
-@test cache==nothing
+# Cache contains iterations counts history
+@test cache isa NamedTuple
+@test cache.num_boostings_done == [100]
 
 @test isa(report, Tuple)
 

--- a/test/mlj/multiclass_classifier.jl
+++ b/test/mlj/multiclass_classifier.jl
@@ -47,6 +47,7 @@ misclassification_rate   = sum(yhat .!= y[test])/length(test)
 expected_return_type = Tuple{
     LightGBM.LGBMClassification,
     CategoricalArrays.CategoricalArray,
+    LightGBM.MLJInterface.LGBMClassifier,
 }
 
 @test isa(fitresult, expected_return_type)

--- a/test/mlj/multiclass_classifier.jl
+++ b/test/mlj/multiclass_classifier.jl
@@ -39,8 +39,9 @@ misclassification_rate   = sum(yhat .!= y[test])/length(test)
 # All we can really say about fitting with/without weights for this example is that the solutions shouldn't be identical
 @test yhat_with_weights != yhat
 
-# It's what it should be for now
-@test cache==nothing
+# Cache contains iterations counts history
+@test cache isa NamedTuple
+@test cache.num_boostings_done == [100]
 
 @test isa(report, Tuple)
 

--- a/test/mlj/regression.jl
+++ b/test/mlj/regression.jl
@@ -43,6 +43,7 @@ rmse_weights             = calc_rmse(y[test], yhat_with_weights)
 expected_return_type = Tuple{
     LightGBM.LGBMRegression,
     Vector{Any}, # blep
+    LightGBM.MLJInterface.LGBMRegressor,
 }
 
 @test isa(fitresult, expected_return_type)

--- a/test/mlj/regression.jl
+++ b/test/mlj/regression.jl
@@ -35,8 +35,9 @@ rmse_weights             = calc_rmse(y[test], yhat_with_weights)
 @test rmse < 0.05
 @test !isapprox(rmse, rmse_weights, rtol=0.1) # check that they differ by at least around 10% with/without weights
 
-# It's what it should be for now
-@test cache==nothing
+# Cache contains iterations counts history
+@test cache isa NamedTuple
+@test cache.num_boostings_done == [100]
 
 @test isa(report, Tuple)
 

--- a/test/mlj/update.jl
+++ b/test/mlj/update.jl
@@ -6,75 +6,111 @@ using Test
 
 import LightGBM
 
-# First, generate a large-ish garbage dataset
-nrows = 20_000
-nfeatures = 200
+# Setup stuff
+nrows = 3_000
+nfeatures = 10
 
 x = randn(nrows, nfeatures)
 y = randn(nrows)
 k = Dict(Symbol(i) => Int64(i) for i in 1:nfeatures)
 X = MLJBase.Tables.MatrixTable(collect(keys(k)), k, x)
+w = abs.(randn(nrows))
+w = w / sum(w)
 
-# setup MLJ machinery
+# setup MLJ machinery -- will be used in several testsets
 r = LightGBM.MLJInterface.LGBMRegressor(num_iterations=1, min_data_in_leaf=20)
 m = MLJBase.machine(r, X, y)
 
-# lets fit it
+# initial fit
 MLJBase.fit!(m; verbosity=0)
 
-# machine keeps a field `fitresult` which is the the fitresult,
-# the first element of this tuple is the LGBMEstimator
-iteration_count = LightGBM.get_iter_number(first(m.fitresult))
-cached_iteration_count = sum(m.cache.num_boostings_done)
-@test iteration_count == 1
-@test iteration_count == cached_iteration_count
-@test m.cache.num_boostings_done == [1]
 
-# check an update chaining on from a fit works
-m.model.num_iterations += 10
+@testset "MLJ update" begin
+    # machine keeps a field `fitresult` which is the the fitresult,
+    # the first element of this tuple is the LGBMEstimator
+    iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+    cached_iteration_count = sum(m.cache.num_boostings_done)
+    @test iteration_count == 1
+    @test iteration_count == cached_iteration_count
+    @test m.cache.num_boostings_done == [1]
 
-MLJBase.fit!(m; verbosity=0)
+    # check an update chaining on from a fit works
+    m.model.num_iterations += 10
 
-iteration_count = LightGBM.get_iter_number(first(m.fitresult))
-cached_iteration_count = sum(m.cache.num_boostings_done)
-@test iteration_count == 11
-@test iteration_count == cached_iteration_count
-@test m.cache.num_boostings_done == [1, 10]
+    MLJBase.fit!(m; verbosity=0)
 
-# check an update chaining on from an update works
-m.model.num_iterations += 5
-
-MLJBase.fit!(m; verbosity=0)
-
-iteration_count = LightGBM.get_iter_number(first(m.fitresult))
-cached_iteration_count = sum(m.cache.num_boostings_done)
-@test iteration_count == 16
-@test iteration_count == cached_iteration_count
-@test m.cache.num_boostings_done == [1, 10, 5]
+    iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+    cached_iteration_count = sum(m.cache.num_boostings_done)
+    @test iteration_count == 11
+    @test iteration_count == cached_iteration_count
+    @test m.cache.num_boostings_done == [1, 10]
+end
 
 
-# refit from scratch, num_iterations is 16 (via modifications)
-# and MLJ should call the fit interface internally -- demonstrate this
-MLJBase.fit!(m; force=true, verbosity=0)
+@testset "MLJ update chain" begin
+    # check an update chaining on from an update works
+    m.model.num_iterations += 5
 
-iteration_count = LightGBM.get_iter_number(first(m.fitresult))
-cached_iteration_count = sum(m.cache.num_boostings_done)
-@test iteration_count == 16
-@test iteration_count == cached_iteration_count
-@test m.cache.num_boostings_done == [16]
+    MLJBase.fit!(m; verbosity=0)
+
+    iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+    cached_iteration_count = sum(m.cache.num_boostings_done)
+    @test iteration_count == 16
+    @test iteration_count == cached_iteration_count
+    @test m.cache.num_boostings_done == [1, 10, 5]
+
+end
+
+@testset "MLJ update less iterations triggers refit" begin
+    m.model.num_iterations -= 1
+    MLJBase.fit!(m; force=true, verbosity=0)
+
+    iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+    cached_iteration_count = sum(m.cache.num_boostings_done)
+    @test iteration_count == 15
+    @test iteration_count == cached_iteration_count
+    @test m.cache.num_boostings_done == [15]
+end
 
 
-# next, check that  changing parameters other than num_iterations results in entirely refitting
-m.model.num_iterations += 1
-m.model.min_data_in_leaf += 5
+@testset "MLJ update non-updatable parameters" begin
+    # next, check that  changing parameters other than num_iterations results in entirely refitting
+    m.model.num_iterations += 1
+    m.model.min_data_in_leaf += 5
 
-MLJBase.fit!(m; verbosity=0)
+    MLJBase.fit!(m; verbosity=0)
 
-iteration_count = LightGBM.get_iter_number(first(m.fitresult))
-cached_iteration_count = sum(m.cache.num_boostings_done)
-@test iteration_count == 17
-@test iteration_count == cached_iteration_count
-@test m.cache.num_boostings_done == [17]
+    iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+    cached_iteration_count = sum(m.cache.num_boostings_done)
+    @test iteration_count == 16
+    @test iteration_count == cached_iteration_count
+    @test m.cache.num_boostings_done == [16]
+end
+
+
+@testset "MLJ User provided weights" begin
+# check with user provided weights
+    r = LightGBM.MLJInterface.LGBMRegressor(num_iterations=1, min_data_in_leaf=20)
+    weights_machine = MLJBase.machine(r, X, y, w)
+
+    MLJBase.fit!(weights_machine; verbosity=0)
+
+    iteration_count = LightGBM.get_iter_number(first(weights_machine.fitresult))
+    cached_iteration_count = sum(weights_machine.cache.num_boostings_done)
+    @test iteration_count == 1
+    @test iteration_count == cached_iteration_count
+    @test weights_machine.cache.num_boostings_done == [1]
+
+    weights_machine.model.num_iterations += 1
+    MLJBase.fit!(weights_machine; verbosity=0)
+
+    iteration_count = LightGBM.get_iter_number(first(weights_machine.fitresult))
+    cached_iteration_count = sum(weights_machine.cache.num_boostings_done)
+    @test iteration_count == 2
+    @test iteration_count == cached_iteration_count
+    @test weights_machine.cache.num_boostings_done == [1, 1]
+
+end
+
 
 end # module
-true

--- a/test/mlj/update.jl
+++ b/test/mlj/update.jl
@@ -1,0 +1,80 @@
+module TestUpdateMethod
+
+
+using MLJBase
+using Test
+
+import LightGBM
+
+# First, generate a large-ish garbage dataset
+nrows = 20_000
+nfeatures = 200
+
+x = randn(nrows, nfeatures)
+y = randn(nrows)
+k = Dict(Symbol(i) => Int64(i) for i in 1:nfeatures)
+X = MLJBase.Tables.MatrixTable(collect(keys(k)), k, x)
+
+# setup MLJ machinery
+r = LightGBM.MLJInterface.LGBMRegressor(num_iterations=1, min_data_in_leaf=20)
+m = MLJBase.machine(r, X, y)
+
+# lets fit it
+MLJBase.fit!(m; verbosity=0)
+
+# machine keeps a field `fitresult` which is the the fitresult,
+# the first element of this tuple is the LGBMEstimator
+iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+cached_iteration_count = sum(m.cache.num_boostings_done)
+@test iteration_count == 1
+@test iteration_count == cached_iteration_count
+@test m.cache.num_boostings_done == [1]
+
+# check an update chaining on from a fit works
+m.model.num_iterations += 10
+
+MLJBase.fit!(m; verbosity=0)
+
+iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+cached_iteration_count = sum(m.cache.num_boostings_done)
+@test iteration_count == 11
+@test iteration_count == cached_iteration_count
+@test m.cache.num_boostings_done == [1, 10]
+
+# check an update chaining on from an update works
+m.model.num_iterations += 5
+
+MLJBase.fit!(m; verbosity=0)
+
+iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+cached_iteration_count = sum(m.cache.num_boostings_done)
+@test iteration_count == 16
+@test iteration_count == cached_iteration_count
+@test m.cache.num_boostings_done == [1, 10, 5]
+
+
+# refit from scratch, num_iterations is 16 (via modifications)
+# and MLJ should call the fit interface internally -- demonstrate this
+MLJBase.fit!(m; force=true, verbosity=0)
+
+iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+cached_iteration_count = sum(m.cache.num_boostings_done)
+@test iteration_count == 16
+@test iteration_count == cached_iteration_count
+@test m.cache.num_boostings_done == [16]
+
+
+# next, check that  changing parameters other than num_iterations results in entirely refitting
+m.model.num_iterations += 1
+m.model.min_data_in_leaf += 5
+
+MLJBase.fit!(m; verbosity=0)
+
+iteration_count = LightGBM.get_iter_number(first(m.fitresult))
+cached_iteration_count = sum(m.cache.num_boostings_done)
+@test iteration_count == 17
+@test iteration_count == cached_iteration_count
+@test m.cache.num_boostings_done == [17]
+
+end # module
+true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,10 @@ end
         include(joinpath("mlj", "regression.jl"))
     end
 
+    @testset "MLJ update interface" begin
+        include(joinpath("mlj", "update.jl"))
+    end
+
 end
 
 


### PR DESCRIPTION
Currently a WIP to implement the `update` method, effectively allowing to support learning curves over number of iteration. It isn't clear that other parameters can/should be supported for this, but this can be considered if a strong argument can be made for it.

Intention is to make this work by passing number of iterations to the fitting method, such that we could re-call fit with a number of additional iterations to perform on an existing fitted booster.

Have implemented multiple dispatch for num_iterations in fit, next part is to plumb it into MLJ interface.