### PR TITLE
MLJ: Feature importances in user fitreport

### DIFF
--- a/test/basic/evaluation_metrics.jl
+++ b/test/basic/evaluation_metrics.jl
@@ -61,4 +61,27 @@ using LightGBM
 
 end
 
+
+@testset "empty merge_scores" begin
+
+    # basically this test is just to make sure it works properly even when metrics is empty
+
+    a = Dict{String, Vector{Float64}}()
+    b = Dict{String, Vector{Float64}}()
+
+    c = LightGBM.merge_scores(a, b)
+
+    @test typeof(c) == typeof(a)
+    @test isempty(c)
+
+    d1 = Dict{String, typeof(a)}()
+    d2 = Dict{String, typeof(a)}()
+
+    d3 = LightGBM.merge_scores(d1, d2)
+
+    @test typeof(d3) == typeof(d1)
+    @test isempty(d3)
+
+end
+
 end # module

--- a/test/basic/evaluation_metrics.jl
+++ b/test/basic/evaluation_metrics.jl
@@ -1,0 +1,64 @@
+module TestEvaluationMetrics
+
+using Test
+using LightGBM
+
+
+@testset "merge_scores" begin
+
+    a = Dict(
+        "dataset_a" => Dict(
+            "some_metric" => [1., 2.],
+            "another_metric" => [2.2, 3.3],
+        ),
+        "dataset_b" => Dict(
+            "dodo_metric" => [0., 0.],
+            "great_metric" => [0.1, 0.2],
+        ),
+    )
+
+    b = Dict(
+        "dataset_a" => Dict(
+            "some_metric" => [3., 4.],
+            "another_metric" => [4.4, 5.5],
+        ),
+        "dataset_b" => Dict(
+            "dodo_metric" => [1., 1.],
+            "great_metric" => [0.3, 0.4],
+        ),
+    )
+
+    a_copy = deepcopy(a)
+    b_copy = deepcopy(b)
+
+    c = LightGBM.merge_scores(a, b)
+
+    # check no mutate
+    @test a == a_copy
+    @test b == b_copy
+
+    # check no weird key munging from top/lower layer
+    @test sort(collect(keys(c))) == ["dataset_a", "dataset_b"]
+    @test sort(collect(keys(c["dataset_a"]))) == ["another_metric", "some_metric"]
+    @test sort(collect(keys(c["dataset_b"]))) == ["dodo_metric", "great_metric"]
+
+    # check the metrics concated properly
+    @test c["dataset_a"]["some_metric"] == [1., 2., 3., 4.]
+    @test c["dataset_a"]["another_metric"] == [2.2, 3.3, 4.4, 5.5]
+    @test c["dataset_b"]["dodo_metric"] == [0., 0., 1., 1.]
+    @test c["dataset_b"]["great_metric"] == [0.1, 0.2, 0.3, 0.4]
+
+
+    d1 = Dict("breakme" => Dict{String, Vector{Float64}}())
+    d2 = Dict("breakme2" => Dict{String, Vector{Float64}}())
+
+    @test_throws ErrorException LightGBM.merge_scores(d1, d2)
+
+    e1 = Dict("ametric" => [1., 1., 1.])
+    e2 = Dict("bmetric" => [1., 1., 1.])
+
+    @test_throws ErrorException LightGBM.merge_scores(e1, e2)
+
+end
+
+end # module

--- a/test/basic/parameters.jl
+++ b/test/basic/parameters.jl
@@ -1,7 +1,6 @@
 module TestParameters
 
 using Test
-using DelimitedFiles
 using LightGBM
 
 

--- a/test/mlj/binary_classifier.jl
+++ b/test/mlj/binary_classifier.jl
@@ -44,7 +44,7 @@ misclassification_rate   = sum(yhat .!= y[test])/length(test)
 @test cache isa NamedTuple
 @test cache.num_boostings_done == [100]
 
-@test isa(report, Tuple)
+@test isa(report, NamedTuple)
 
 expected_return_type = Tuple{
     LightGBM.LGBMClassification,

--- a/test/mlj/multiclass_classifier.jl
+++ b/test/mlj/multiclass_classifier.jl
@@ -43,7 +43,7 @@ misclassification_rate   = sum(yhat .!= y[test])/length(test)
 @test cache isa NamedTuple
 @test cache.num_boostings_done == [100]
 
-@test isa(report, Tuple)
+@test isa(report, NamedTuple)
 
 expected_return_type = Tuple{
     LightGBM.LGBMClassification,

--- a/test/mlj/regression.jl
+++ b/test/mlj/regression.jl
@@ -39,7 +39,7 @@ rmse_weights             = calc_rmse(y[test], yhat_with_weights)
 @test cache isa NamedTuple
 @test cache.num_boostings_done == [100]
 
-@test isa(report, Tuple)
+@test isa(report, NamedTuple)
 
 expected_return_type = Tuple{
     LightGBM.LGBMRegression,

--- a/test/mlj/update.jl
+++ b/test/mlj/update.jl
@@ -61,6 +61,7 @@ end
 
 end
 
+
 @testset "MLJ update less iterations triggers refit" begin
     m.model.num_iterations -= 1
     MLJBase.fit!(m; verbosity=0)

--- a/test/mlj/user_report.jl
+++ b/test/mlj/user_report.jl
@@ -1,0 +1,53 @@
+module TestMLJUserReport
+
+using MLJBase
+using Test
+
+import LightGBM
+
+
+# Setup stuff
+nrows = 500
+nfeatures = 10
+
+x = randn(nrows, nfeatures)
+y = randn(nrows)
+
+
+@testset "MLJ user report structure" begin
+
+    # by settoing metric freq to 2 we can check the frequency is occurring correctly,
+    # first time we expect only 2 metrics and then (metric @iter0 and metric @iter2)
+    # if we go for 3 more iterations we expect 1 more metric
+    estimator = LightGBM.LGBMRegression(;num_iterations=3, is_training_metric=true, metric=["l2"], metric_freq=2)
+    metrics = LightGBM.fit!(estimator, x, y; verbosity=-1)
+
+    report = LightGBM.MLJInterface.user_fitreport(estimator, metrics)
+
+    # check types (loosely)
+    @test report isa NamedTuple{(:training_metrics, :importance)}
+    @test report.training_metrics isa Dict
+    @test report.importance isa NamedTuple{(:gain, :split)}
+    # check value properties
+    @test length(report.importance.gain) == nfeatures
+    @test length(report.importance.split) == nfeatures
+    @test length(report.training_metrics["training"]["l2"]) == 2
+
+    # continue for another 3 iterations, and check that the metrics lengths update properly
+    new_metrics = LightGBM.train!(estimator, 3, String[], -1, LightGBM.Dates.now())
+
+    new_report = LightGBM.MLJInterface.user_fitreport(estimator, metrics, new_metrics)
+
+    # repeat all same tests except training metrics is now 3, not 1
+    @test new_report isa NamedTuple{(:training_metrics, :importance)}
+    @test new_report.training_metrics isa Dict
+    @test new_report.importance isa NamedTuple{(:gain, :split)}
+    # check value properties
+    @test length(new_report.importance.gain) == nfeatures
+    @test length(new_report.importance.split) == nfeatures
+    @test length(new_report.training_metrics["training"]["l2"]) == 3
+
+end
+
+
+end # module

--- a/test/mlj/user_report.jl
+++ b/test/mlj/user_report.jl
@@ -47,6 +47,18 @@ y = randn(nrows)
     @test length(new_report.importance.split) == nfeatures
     @test length(new_report.training_metrics["training"]["l2"]) == 3
 
+
+    # check metrics are right when freq is just 1
+    new_estimator = LightGBM.LGBMRegression(;num_iterations=3, is_training_metric=true, metric=["l2"], metric_freq=1)
+    freq_metrics = LightGBM.fit!(new_estimator, x, y; verbosity=-1)
+
+    report = LightGBM.MLJInterface.user_fitreport(new_estimator, freq_metrics)
+    @test length(report.training_metrics["training"]["l2"]) == 3
+
+    new_freq_metrics = LightGBM.train!(new_estimator, 7, String[], -1, LightGBM.Dates.now())
+    new_report = LightGBM.MLJInterface.user_fitreport(new_estimator, freq_metrics, new_freq_metrics)
+    @test length(new_report.training_metrics["training"]["l2"]) == 10
+
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,10 @@ end
         include(joinpath("basic", "parameters.jl"))
     end
 
+    @testset "Estimator parameters" begin
+        include(joinpath("basic", "evaluation_metrics.jl"))
+    end
+
 end
 
 @testset "Integration tests" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,10 @@ end
         include(joinpath("mlj", "update.jl"))
     end
 
+    @testset "MLJ update interface" begin
+        include(joinpath("mlj", "user_report.jl"))
+    end
+
 end
 
 


### PR DESCRIPTION
This is the first real use of the user report containing anything of note

* Integrated feature importances into  the report
* Added tests to try and control the shape of the data structure (namedtuple) and ensure breaking changes don't occur in future (this is a breaking change as it is)
* Implemented a metrics merger function as a result of supporting `MLJ.update` without losing previous metrics history
* Reworked how metrics storage is computed in light of metrics being evaluated over partial runs (some iterations here, some more iterations there)