### PR TITLE
Make the categorical_feature designation available

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -266,7 +266,7 @@ function stringifyparams(estimator::LGBMEstimator, params::Vector{Symbol})
             if !isempty(param_value)
                 # Convert parameters that contain indices to C's zero-based indices.
                 if in(param_name, INDEXPARAMS)
-                    param_value -= 1
+                    param_value .-= 1
                 end
 
                 if typeof(param_value) <: Array

--- a/test/basic/utils.jl
+++ b/test/basic/utils.jl
@@ -1,0 +1,10 @@
+using LightGBM
+
+@testset "stringifyparams -- convert to zero-based" begin
+    indices = [1, 3, 5, 7, 9]
+    classifier = LightGBM.LGBMClassification(categorical_feature = indices)
+    ds_parameters = LightGBM.stringifyparams(classifier, LightGBM.DATASETPARAMS)
+
+    expected = "categorical_feature=0,2,4,6,8"
+    @test occursin(expected, ds_parameters)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,9 @@ end
         include(joinpath("basic", "evaluation_metrics.jl"))
     end
 
+    @testset "Utils" begin
+        include(joinpath("basic", "utils.jl"))
+    end
 end
 
 @testset "Integration tests" begin


### PR DESCRIPTION
I fixed subtract operation of a scalar from an array to make the categorical_feature designation available.

Because `categorical_feature::Vector{Int}` and `INDEXPARAMS = [:categorical_feature]`,
```
# Convert parameters that contain indices to C's zero-based indices.
if in(param_name, INDEXPARAMS)
    param_value -= 1
end
```
resulted in
```
MethodError: no method matching -(::Array{Int64,1}, ::Int64)
For element-wise subtraction, use broadcasting with dot syntax: array .- scalar
```

I just inserted a dot.