### PR TITLE
cv-with-pre-constructed-datasets

### DIFF
--- a/src/cv.jl
+++ b/src/cv.jl
@@ -32,11 +32,10 @@ function cv(estimator::LGBMEstimator, X::Matrix{TX}, y::Vector{Ty}, splits;
 end
 
 # Pass Dataset class directly. This will speed up the process if it is part of an iterative process and a pre-constructed dataset is available
-function cv(estimator::LGBMEstimator, dataset::Dataset, splits;
-    verbosity::Integer = 1)
+function cv(estimator::LGBMEstimator, dataset::Dataset, splits; verbosity::Integer = 1)
     start_time = now()
     num_data = LGBM_DatasetGetNumData(dataset)
-    ds_parameters = stringifyparams(estimator, DATASETPARAMS)
+    ds_parameters = stringifyparams(estimator, DATASETPARAMS) * " verbosity=$verbosity"
     bst_parameters = stringifyparams(estimator, BOOSTERPARAMS) * " verbosity=$verbosity"
 
     split_scores = Dict{String,Dict{String,Vector{Float64}}}()

--- a/src/search_cv.jl
+++ b/src/search_cv.jl
@@ -4,6 +4,8 @@
 Exhaustive search over the specified sets of parameter values for the `estimator` with features
 data `X` and label `y`. The iterable `splits` provides vectors of indices for the training dataset.
 The remaining indices are used to create the validation dataset.
+Alternatively, search_cv can be called with an input Dataset class
+
 
 Return an array with a tuple for each set of parameters value, where the first entry is a set of
 parameter values and the second entry the cross-validation outcome of those values. This outcome is
@@ -17,6 +19,7 @@ iteration.
 * `estimator::LGBMEstimator`: the estimator to be fit.
 * `X::Matrix{TX<:Real}`: the features data.
 * `y::Vector{Ty<:Real}`: the labels.
+* `dataset::Dataset`: prepared dataset (either (X, y), or dataset needs to be specified as input)
 * `splits`: the iterable providing arrays of indices for the training dataset.
 * `params`: the iterable providing dictionaries of pairs of parameters (Symbols) and values to
     configure the `estimator` with.
@@ -25,6 +28,19 @@ iteration.
 """
 function search_cv(estimator::LGBMEstimator, X::Matrix{TX}, y::Vector{Ty},
                                       splits, params; verbosity::Integer = 1) where {TX<:Real,Ty<:Real}
+
+    ds_parameters = stringifyparams(estimator, DATASETPARAMS)
+    full_ds = LGBM_DatasetCreateFromMat(X, ds_parameters)
+    LGBM_DatasetSetField(full_ds, "label", y)
+                                                                    
+    return search_cv(estimator, full_ds, splits, params, verbosity = verbosity)
+end
+
+# Pass Dataset class directly. This will speed up the process if it is part of an iterative process and a pre-constructed dataset is available
+function search_cv(
+    estimator::LGBMEstimator, dataset::Dataset, splits, params; 
+    verbosity::Integer = 1
+)
     n_params = length(params)
     results = Array{Tuple{Dict{Symbol,Any},Dict{String,Dict{String,Vector{Float64}}}}}(undef,n_params)
     for (search_idx, search_params) in enumerate(params)
@@ -32,8 +48,8 @@ function search_cv(estimator::LGBMEstimator, X::Matrix{TX}, y::Vector{Ty},
 
         search_estimator = deepcopy(estimator)
         foreach(param -> setfield!(search_estimator, param[1], param[2]), search_params)
-        search_results = cv(search_estimator, X, y, deepcopy(splits),
-                            verbosity = ifelse(verbosity == 1, 0, verbosity))
+        search_results = cv(search_estimator, dataset, deepcopy(splits),
+        verbosity = ifelse(verbosity == 1, 0, verbosity))
 
         results[search_idx] = (search_params, search_results)
         cv_logsummary(search_results, verbosity)

--- a/test/basic/cv.jl
+++ b/test/basic/cv.jl
@@ -1,4 +1,4 @@
-module TestFit
+module TestCv
 
 include("../../src/LightGBM.jl")
 

--- a/test/basic/cv.jl
+++ b/test/basic/cv.jl
@@ -1,0 +1,51 @@
+module TestFit
+
+include("../../src/LightGBM.jl")
+
+using Test
+using LightGBM
+
+train_matrix = rand(1000,70) # create random dataset
+train_labels = rand([0, 1], 1000)
+splits = (
+    collect(1:200), collect(201:400),
+    collect(401:600), collect(601:800),
+    collect(801:1000)
+)
+
+estimator = LightGBM.LGBMClassification(
+    objective = "binary", 
+    num_class = 1,
+    is_training_metric = true, 
+    metric = ["auc"]
+)
+
+
+@testset "test cv with X y input -- binary" begin
+    # Act
+    output = LightGBM.cv(estimator, train_matrix, train_labels, splits, verbosity = -1);
+
+    # Assert
+    @test output isa Dict{String,Dict{String,Vector{Float64}}}
+    @test length(output["validation"]["auc"]) == 5
+    @test length(output["training"]["auc"]) == 5
+end
+
+
+@testset "test cv with Dataset input -- binary" begin
+    # Arrange
+    train_dataset = LightGBM.LGBM_DatasetCreateFromMat(train_matrix, "")
+    LightGBM.LGBM_DatasetSetField(train_dataset, "label", train_labels)
+
+    # Act
+    output = LightGBM.cv(estimator, train_dataset, splits, verbosity = -1);
+
+    # Assert
+    @test output isa Dict{String,Dict{String,Vector{Float64}}}
+    @test length(output["validation"]["auc"]) == 5
+    @test length(output["training"]["auc"]) == 5
+end
+
+
+
+end # module

--- a/test/basic/search_cv.jl
+++ b/test/basic/search_cv.jl
@@ -1,4 +1,4 @@
-module TestFit
+module TestSearchCv
 
 include("../../src/LightGBM.jl")
 
@@ -54,7 +54,6 @@ end
     @test length(output[1][2]["validation"]["auc"]) == 5
     @test length(output[1][2]["training"]["auc"]) == 5
 end
-
 
 
 end # module

--- a/test/basic/search_cv.jl
+++ b/test/basic/search_cv.jl
@@ -1,0 +1,60 @@
+module TestFit
+
+include("../../src/LightGBM.jl")
+
+using Test
+using LightGBM
+
+train_matrix = rand(1000,70) # create random dataset
+train_labels = rand([0, 1], 1000)
+splits = (
+    collect(1:200), collect(201:400),
+    collect(401:600), collect(601:800),
+    collect(801:1000)
+)
+params = [
+    Dict(:num_iterations => num_iterations, :num_leaves => num_leaves)
+    for num_iterations in (1, 2), num_leaves in (5, 10)
+]
+
+estimator = LightGBM.LGBMClassification(
+    objective = "binary", 
+    num_class = 1,
+    is_training_metric = true, 
+    metric = ["auc"]
+)
+
+
+
+@testset "test search_cv with X y input -- binary" begin
+    # Act
+    output = LightGBM.search_cv(estimator, train_matrix, train_labels, splits, params, verbosity = -1);
+
+    # Assert
+    @test output isa Array{Tuple{Dict{Symbol,Any},Dict{String,Dict{String,Vector{Float64}}}}}
+    @test :num_iterations in keys(output[1][1])
+    @test :num_leaves in keys(output[1][1])
+    @test length(output[1][2]["validation"]["auc"]) == 5
+    @test length(output[1][2]["training"]["auc"]) == 5
+end
+
+
+@testset "test search_cv with Dataset input -- binary" begin
+    # Arrange
+    train_dataset = LightGBM.LGBM_DatasetCreateFromMat(train_matrix, "")
+    LightGBM.LGBM_DatasetSetField(train_dataset, "label", train_labels)
+
+    # Act
+    output = LightGBM.search_cv(estimator, train_dataset, splits, params, verbosity = -1);
+
+    # Assert
+    @test output isa Array{Tuple{Dict{Symbol,Any},Dict{String,Dict{String,Vector{Float64}}}}}
+    @test :num_iterations in keys(output[1][1])
+    @test :num_leaves in keys(output[1][1])
+    @test length(output[1][2]["validation"]["auc"]) == 5
+    @test length(output[1][2]["training"]["auc"]) == 5
+end
+
+
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,14 @@ end
         include(joinpath("basic", "fit.jl"))
     end
 
+    @testset "CV" begin
+        include(joinpath("basic", "cv.jl"))
+    end
+
+    @testset "Search CV" begin
+        include(joinpath("basic", "search_cv.jl"))
+    end
+
 end
 
 @testset "Integration tests" begin


### PR DESCRIPTION
Modified functions cv and search_cv to allow inputs with pre-constructed datasets.

This will speed up the process if it is part of an iterative process and a pre-constructed dataset is available

