### PR TITLE
correct predict output shape

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LightGBM"
 uuid = "7acf609c-83a4-11e9-1ffb-b912bcd3b04a"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ search_cv(estimator, X_train, y_train, splits, params)
 # Save and load the fitted model.
 filename = pwd() * "/finished.model"
 savemodel(estimator, filename)
-loadmodel(estimator, filename)
+loadmodel!(estimator, filename)
 ```
 
 # MLJ Support

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -106,7 +106,7 @@ search_cv(estimator, X_train, y_train, splits, params)
 # Save and load the fitted model.
 filename = pwd() * "/finished.model"
 savemodel(estimator, filename)
-loadmodel(estimator, filename)
+loadmodel!(estimator, filename)
 ```
 
 # Parameters

--- a/src/LightGBM.jl
+++ b/src/LightGBM.jl
@@ -18,7 +18,7 @@ include("cv.jl")
 include("search_cv.jl")
 include(joinpath(@__DIR__, "MLJInterface.jl"))
 
-export fit!, predict, predict_classes, cv, search_cv, savemodel, loadmodel
+export fit!, predict, predict_classes, cv, search_cv, savemodel, loadmodel!
 export LGBMEstimator, LGBMRegression, LGBMClassification
 
 end # module LightGBM

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -64,7 +64,7 @@ function savemodel(
 end
 
 """
-    loadmodel(estimator, filename)
+    loadmodel!(estimator, filename)
 
 Load the fitted model `filename` into `estimator`. Note that this only loads the fitted model—not
 the parameters or data of the estimator whose model was saved as `filename`.
@@ -73,8 +73,9 @@ the parameters or data of the estimator whose model was saved as `filename`.
 * `estimator::LGBMEstimator`: the estimator to use in the prediction.
 * `filename::String`: the name of the file that contains the model.
 """
-function loadmodel(estimator::LGBMEstimator, filename::String)
+function loadmodel!(estimator::LGBMEstimator, filename::String)
     estimator.booster = LGBM_BoosterCreateFromModelfile(filename)
+    estimator.num_class = LGBM_BoosterGetNumClasses(estimator.booster)
     return nothing
 end
 

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -587,7 +587,6 @@ function LGBM_BoosterPredictForMat(
     is_row_major::Bool = false
 ) where T<:Union{Float32,Float64}
 
-    num_class = LGBM_BoosterGetNumClasses(bst)
     lgbm_data_type = jltype_to_lgbmid(T)
     nrow, ncol = ifelse(is_row_major, reverse(size(data)), size(data))
     out_len = Ref{Int64}()

--- a/test/basic/test_cv.jl
+++ b/test/basic/test_cv.jl
@@ -1,7 +1,5 @@
 module TestCv
 
-include("../../src/LightGBM.jl")
-
 using Test
 using LightGBM
 

--- a/test/basic/test_fit.jl
+++ b/test/basic/test_fit.jl
@@ -1,7 +1,5 @@
 module TestFit
 
-include("../../src/LightGBM.jl")
-
 using Test
 using Dates
 using LightGBM

--- a/test/basic/test_search_cv.jl
+++ b/test/basic/test_search_cv.jl
@@ -1,7 +1,5 @@
 module TestSearchCv
 
-include("../../src/LightGBM.jl")
-
 using Test
 using LightGBM
 

--- a/test/basic/test_utils.jl
+++ b/test/basic/test_utils.jl
@@ -1,4 +1,9 @@
+using Test
 using LightGBM
+
+X_train = randn(1000, 20)
+y_train_binary = rand(0:1, 1000)
+y_train_regression = rand(1000)
 
 @testset "stringifyparams -- convert to zero-based" begin
     indices = [1, 3, 5, 7, 9]
@@ -7,4 +12,50 @@ using LightGBM
 
     expected = "categorical_feature=0,2,4,6,8"
     @test occursin(expected, ds_parameters)
+end
+
+
+
+@testset "loadmodel predicts same as original model -- regression" begin
+    # Arrange
+    estimator = LightGBM.LGBMRegression(objective = "regression")
+    LightGBM.fit!(estimator, X_train, y_train_regression)
+    expected_prediction = predict(estimator, X_train)
+    # Save the fitted model.
+    model_filename = joinpath(@__DIR__, "fixture.model")
+    savemodel(estimator, model_filename)
+  
+    # Act
+    estimator_from_file = LGBMRegression()
+    loadmodel!(estimator_from_file, model_filename)
+    actual_prediction = predict(estimator_from_file, X_train)
+
+    # Assert
+    @test expected_prediction == actual_prediction
+
+    # Teardown
+    rm(model_filename)
+
+end
+
+
+@testset "loadmodel predicts same as original model -- binary" begin
+    # Arrange
+    estimator = LightGBM.LGBMClassification(objective = "binary", num_class = 1)
+    LightGBM.fit!(estimator, X_train, y_train_binary)
+    expected_prediction = predict(estimator, X_train)
+    # Save the fitted model.
+    model_filename = joinpath(@__DIR__, "fixture.model")
+    savemodel(estimator, model_filename)
+
+    # Act
+    estimator_from_file = LGBMClassification()
+    loadmodel!(estimator_from_file, model_filename)
+    actual_prediction = predict(estimator_from_file, X_train)
+
+    # Assert
+    @test expected_prediction == actual_prediction
+
+    # Teardown
+    rm(model_filename)
 end

--- a/test/basic/test_utils.jl
+++ b/test/basic/test_utils.jl
@@ -1,3 +1,5 @@
+module TestUtils
+
 using Test
 using LightGBM
 
@@ -59,3 +61,70 @@ end
     # Teardown
     rm(model_filename)
 end
+
+@testset "loadmodel predicts same as original model with custom pararms -- regression" begin
+    # Arrange
+    estimator = estimator = LGBMRegression(
+        objective = "regression",
+        num_iterations = 100,
+        learning_rate = .2,
+        early_stopping_round = 3,
+        feature_fraction = .5,
+        bagging_fraction = .6,
+        bagging_freq = 2,
+        num_leaves = 100,
+        metric = ["auc", "binary_logloss"]
+    )
+    LightGBM.fit!(estimator, X_train, y_train_regression)
+    expected_prediction = predict(estimator, X_train)
+    # Save the fitted model.
+    model_filename = joinpath(@__DIR__, "fixture.model")
+    savemodel(estimator, model_filename)
+  
+    # Act
+    estimator_from_file = LGBMRegression()
+    loadmodel!(estimator_from_file, model_filename)
+    actual_prediction = predict(estimator_from_file, X_train)
+
+    # Assert
+    @test expected_prediction == actual_prediction
+
+    # Teardown
+    rm(model_filename)
+
+end
+
+
+@testset "loadmodel predicts same as original model with custom params -- binary" begin
+    # Arrange
+    estimator = estimator = LGBMClassification(
+        objective = "binary",
+        num_iterations = 100,
+        learning_rate = .2,
+        early_stopping_round = 3,
+        feature_fraction = .5,
+        bagging_fraction = .6,
+        bagging_freq = 2,
+        num_leaves = 100,
+        num_class = 1,
+        metric = ["auc", "binary_logloss"]
+    )
+    LightGBM.fit!(estimator, X_train, y_train_binary)
+    expected_prediction = predict(estimator, X_train)
+    # Save the fitted model.
+    model_filename = joinpath(@__DIR__, "fixture.model")
+    savemodel(estimator, model_filename)
+
+    # Act
+    estimator_from_file = LGBMClassification()
+    loadmodel!(estimator_from_file, model_filename)
+    actual_prediction = predict(estimator_from_file, X_train)
+
+    # Assert
+    @test expected_prediction == actual_prediction
+
+    # Teardown
+    rm(model_filename)
+end
+
+end # Module

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -126,7 +126,7 @@ LGBM_PATH = if isabspath(LGBM_PATH) LGBM_PATH else abspath(joinpath(pwd(), "..",
     LightGBM.savemodel(estimator, test_filename)
 
     pre = LightGBM.predict(estimator, X_train, verbosity = -1)
-    LightGBM.loadmodel(estimator, test_filename);
+    LightGBM.loadmodel!(estimator, test_filename);
     post = LightGBM.predict(estimator, X_train, verbosity = -1)
 
     rm(test_filename)


### PR DESCRIPTION
- Changed `loadmodel` to `loadmodel!` as we are actually modifying the booster with this method
- Currently if we use predict (in /src/predict.jl) on a binary classifier, the output is split into two columns while we only expected it to give one. The reason is that num_class is not loaded when we do `loadmodel!`. So loading in the num_class property when we `loadmodel!` fixes the predict functionality. Have also added tests on this