### PR TITLE
Access the best iteration from early stopping

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -33,6 +33,7 @@ function fit!(
     is_row_major = false,
     weights::Vector{Tw} = Float32[],
     init_score::Vector{Ti} = Float64[],
+    truncate_booster::Bool=true,
 ) where {TX<:Real,Ty<:Real,Tw<:Real,Ti<:Real}
 
     start_time = now()
@@ -56,7 +57,7 @@ function fit!(
         push!(test_dss, test_ds)
     end
 
-    return fit!(estimator, train_ds, test_dss..., verbosity=verbosity)
+    return fit!(estimator, train_ds, test_dss..., verbosity=verbosity, truncate_booster=truncate_booster)
 end
 
 
@@ -66,6 +67,7 @@ function fit!(
     train_dataset::Dataset, 
     test_datasets::Dataset...;
     verbosity::Integer = 1,
+    truncate_booster::Bool=true,
 )
 
     start_time = now()
@@ -82,7 +84,7 @@ function fit!(
     end
 
     log_debug(verbosity, "Started training...\n")
-    results = train!(estimator, tests_names, verbosity, start_time)
+    results = train!(estimator, tests_names, verbosity, start_time, truncate_booster=truncate_booster)
 
     return results
 end
@@ -93,21 +95,26 @@ function train!(
     num_iterations::Int, 
     tests_names::Vector{String}, 
     verbosity::Integer, 
-    start_time::DateTime,
+    start_time::DateTime;
+    truncate_booster::Bool=true,
 )
-    results = Dict{String,Dict{String,Vector{Float64}}}()
+    results = Dict(
+        "best_iter" => 0,
+        "metrics" => Dict{String,Dict{String,Vector{Float64}}}(),
+    )
     metrics = LGBM_BoosterGetEvalNames(estimator.booster)
 
     bigger_is_better = Dict(metric => ifelse(in(metric, MAXIMIZE_METRICS), 1., -1.) for metric in metrics)
-    best_score = Dict{String,Dict{String,Real}}()
-    best_iter = Dict{String,Dict{String,Real}}()
+    best_scores = Dict{String,Dict{String,Real}}()
+    best_iterations = Dict{String,Dict{String,Real}}()
+
 
     for metric in metrics
-        best_score[metric] = Dict{String,Real}()
-        best_iter[metric] = Dict{String,Real}()
+        best_scores[metric] = Dict{String,Real}()
+        best_iterations[metric] = Dict{String,Real}()
         for tests_name in tests_names
-            best_score[metric][tests_name] = -Inf
-            best_iter[metric][tests_name] = 1
+            best_scores[metric][tests_name] = -Inf
+            best_iterations[metric][tests_name] = 1
         end
     end
 
@@ -123,7 +130,7 @@ function train!(
         if is_finished == 0
             is_finished = eval_metrics!(
                 results, estimator, tests_names, iter, verbosity, 
-                bigger_is_better, best_score, best_iter, metrics,
+                bigger_is_better, best_scores, best_iterations, metrics,
             )
         end
 
@@ -132,28 +139,44 @@ function train!(
         end
     end
 
+    if truncate_booster && estimator.early_stopping_round > 0 && results["best_iter"] > 0 # truncate_booster flag on AND early_stopping enabled
+        truncate_model!(estimator, results["best_iter"])
+    end
+
     # save the model in serialised form, in case we should be deepcopied or serialised elsewhere
     estimator.model = LGBM_BoosterSaveModelToString(estimator.booster)
 
     return results
+
 end
 # Old signature, pass through args
 function train!(
-    estimator::LGBMEstimator, tests_names::Vector{String}, verbosity::Integer, start_time::DateTime
+    estimator::LGBMEstimator, tests_names::Vector{String}, verbosity::Integer, start_time::DateTime;
+    truncate_booster::Bool=true,
 )
-    return train!(estimator, estimator.num_iterations, tests_names, verbosity, start_time)
+    return train!(estimator, estimator.num_iterations, tests_names, verbosity, start_time, truncate_booster=truncate_booster)
+end
+
+
+function truncate_model!(estimator::LGBMEstimator, best_iteration::Integer)
+    current_iteration = LGBM_BoosterGetCurrentIteration(estimator.booster)
+    times_to_rollback = current_iteration - best_iteration # current_iteration must be >= best_iteration
+    for _ in [1:times_to_rollback;]
+        LGBM_BoosterRollbackOneIter(estimator.booster)
+    end
+    return nothing
 end
 
 
 function eval_metrics!(
-    results::Dict{String,Dict{String,Vector{Float64}}},
+    results::Dict,
     estimator::LGBMEstimator,
     tests_names::Vector{String},
     iter::Integer,
     verbosity::Integer,
     bigger_is_better::Dict{String,Float64},
-    best_score::Dict{String,Dict{String,Real}},
-    best_iter::Dict{String,Dict{String,Real}},
+    best_scores::Dict{String,Dict{String,Real}},
+    best_iterations::Dict{String,Dict{String,Real}},
     metrics::Vector{String},
 )
     now_scores = Dict{String,Vector{Float64}}()
@@ -173,15 +196,15 @@ function eval_metrics!(
             for (metric_idx, metric) in enumerate(metrics)
                 maximize_score = bigger_is_better[metric] * now_scores[tests_name][metric_idx]
                 # All good if maximize_score is better than previous best
-                if maximize_score > best_score[metric][tests_name]
-                    best_score[metric][tests_name] = maximize_score
-                    best_iter[metric][tests_name] = iter
+                if maximize_score > best_scores[metric][tests_name]
+                    best_scores[metric][tests_name] = maximize_score
+                    best_iterations[metric][tests_name] = results["best_iter"] = iter
                     continue
                 # All good if difference between current and best iter is within early_stopping_round
-                elseif (iter - best_iter[metric][tests_name]) < estimator.early_stopping_round
+                elseif (iter - best_iterations[metric][tests_name]) < estimator.early_stopping_round
                     continue
                 end                
-                log_info(verbosity, "Early stopping at iteration ", iter, ", the best iteration round is ", best_iter[metric][tests_name], "\n")
+                log_info(verbosity, "Early stopping at iteration ", iter, ", the best iteration round is ", best_iterations[metric][tests_name], "\n")
                 return 1
             end
         
@@ -204,22 +227,22 @@ function eval_metrics!(
 end
 
 function store_scores!(
-    results::Dict{String,Dict{String,Vector{Float64}}},
+    results::Dict,
     dataset_key::String,
     metric_name::String,
     value_to_add::Float64,
 )
-    if !haskey(results, dataset_key)
-        results[dataset_key] = Dict{String,Vector{Float64}}()
-        results[dataset_key][metric_name] = Float64[]
-    elseif !haskey(results[dataset_key], metric_name)
-        results[dataset_key][metric_name] = Float64[]
+    if !haskey(results["metrics"], dataset_key)
+        results["metrics"][dataset_key] = Dict{String,Vector{Float64}}()
+        results["metrics"][dataset_key][metric_name] = Float64[]
+    elseif !haskey(results["metrics"][dataset_key], metric_name)
+        results["metrics"][dataset_key][metric_name] = Float64[]
     end
-    push!(results[dataset_key][metric_name], value_to_add)
+    push!(results["metrics"][dataset_key][metric_name], value_to_add)
 end
 
 
-function merge_scores(
+function merge_metrics(
     old_scores::Dict{String,Dict{String,Vector{Float64}}},
     additional_scores::Dict{String,Dict{String,Vector{Float64}}},
 )
@@ -230,14 +253,14 @@ function merge_scores(
 
     new_scores = Dict{String,Dict{String,Vector{Float64}}}()
     for (key, oldvals) in old_scores
-        new_scores[key] = merge_scores(old_scores[key], additional_scores[key])
+        new_scores[key] = merge_metrics(old_scores[key], additional_scores[key])
     end
 
     return new_scores
 end
 
 
-function merge_scores(
+function merge_metrics(
     old_scores::Dict{String,Vector{Float64}},
     additional_scores::Dict{String,Vector{Float64}},
 )

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -161,7 +161,7 @@ end
 function truncate_model!(estimator::LGBMEstimator, best_iteration::Integer)
     current_iteration = LGBM_BoosterGetCurrentIteration(estimator.booster)
     times_to_rollback = current_iteration - best_iteration # current_iteration must be >= best_iteration
-    for _ in [1:times_to_rollback;]
+    for _ in 1:times_to_rollback
         LGBM_BoosterRollbackOneIter(estimator.booster)
     end
     return nothing

--- a/test/basic/test_evaluation_metrics.jl
+++ b/test/basic/test_evaluation_metrics.jl
@@ -4,7 +4,7 @@ using Test
 using LightGBM
 
 
-@testset "merge_scores" begin
+@testset "merge_metrics" begin
 
     a = Dict(
         "dataset_a" => Dict(
@@ -31,7 +31,7 @@ using LightGBM
     a_copy = deepcopy(a)
     b_copy = deepcopy(b)
 
-    c = LightGBM.merge_scores(a, b)
+    c = LightGBM.merge_metrics(a, b)
 
     # check no mutate
     @test a == a_copy
@@ -52,24 +52,24 @@ using LightGBM
     d1 = Dict("breakme" => Dict{String, Vector{Float64}}())
     d2 = Dict("breakme2" => Dict{String, Vector{Float64}}())
 
-    @test_throws ErrorException LightGBM.merge_scores(d1, d2)
+    @test_throws ErrorException LightGBM.merge_metrics(d1, d2)
 
     e1 = Dict("ametric" => [1., 1., 1.])
     e2 = Dict("bmetric" => [1., 1., 1.])
 
-    @test_throws ErrorException LightGBM.merge_scores(e1, e2)
+    @test_throws ErrorException LightGBM.merge_metrics(e1, e2)
 
 end
 
 
-@testset "empty merge_scores" begin
+@testset "empty merge_metrics" begin
 
     # basically this test is just to make sure it works properly even when metrics is empty
 
     a = Dict{String, Vector{Float64}}()
     b = Dict{String, Vector{Float64}}()
 
-    c = LightGBM.merge_scores(a, b)
+    c = LightGBM.merge_metrics(a, b)
 
     @test typeof(c) == typeof(a)
     @test isempty(c)
@@ -77,7 +77,7 @@ end
     d1 = Dict{String, typeof(a)}()
     d2 = Dict{String, typeof(a)}()
 
-    d3 = LightGBM.merge_scores(d1, d2)
+    d3 = LightGBM.merge_metrics(d1, d2)
 
     @test typeof(d3) == typeof(d1)
     @test isempty(d3)

--- a/test/basic/test_mljinterface.jl
+++ b/test/basic/test_mljinterface.jl
@@ -1,0 +1,44 @@
+module TestUtils
+
+
+using MLJBase
+using Test
+
+import LightGBM
+
+
+@testset "mlj_to_kwargs removes classifier truncate_booster flag" begin
+    # Arrange
+    fixture = LightGBM.MLJInterface.LGBMClassifier()
+
+    # Act
+    output = LightGBM.MLJInterface.mlj_to_kwargs(fixture)
+
+    # Assert
+    @test :truncate_booster ∉ keys(output)
+end
+
+@testset "mlj_to_kwargs removes regressor truncate_booster flag" begin
+    # Arrange
+    fixture = LightGBM.MLJInterface.LGBMRegressor()
+
+    # Act
+    output = LightGBM.MLJInterface.mlj_to_kwargs(fixture)
+
+    # Assert
+    @test :truncate_booster ∉ keys(output)
+end
+
+@testset "mlj_to_kwargs adds classifier num_class" begin
+    # Arrange
+    fixture = LightGBM.MLJInterface.LGBMClassifier()
+
+    # Act
+    output = LightGBM.MLJInterface.mlj_to_kwargs(fixture, [0,1])
+
+    # Assert
+    @test :num_class in keys(output)
+end
+
+
+end # Module

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -188,7 +188,7 @@ end
     )
 
     scores = LightGBM.fit!(estimator, X_train, y_train, (X_test, y_test), verbosity = -1)
-    @test scores["test_1"]["l2"][end] < .5
+    @test scores["metrics"]["test_1"]["l2"][end] < .5
 
 end
 
@@ -221,7 +221,7 @@ end
     )
 
     scores = LightGBM.fit!(estimator, X_train, y_train, (X_test, y_test), verbosity = -1)
-    @test scores["test_1"]["multi_logloss"][end] < 1.4
+    @test scores["metrics"]["test_1"]["multi_logloss"][end] < 1.4
 
     # Test row major multiclass
     X_train = Matrix(multiclass_train[:, 2:end]')
@@ -245,7 +245,7 @@ end
     )
 
     scores = LightGBM.fit!(estimator, X_train, y_train, (X_test, y_test), verbosity = -1, is_row_major = true)
-    @test scores["test_1"]["multi_logloss"][end] < 1.4
+    @test scores["metrics"]["test_1"]["multi_logloss"][end] < 1.4
 
 end
 

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -163,8 +163,23 @@ end
 
 @testset "LGBM_BoosterRollbackOneIter" begin
 
-    # I don't know how to test this, needs thought
-    @test_broken false
+    # Arrange
+    mymat = randn(10000, 2)
+    labels = randn(10000)
+    dataset = LightGBM.LGBM_DatasetCreateFromMat(mymat, verbosity)    
+    LightGBM.LGBM_DatasetSetField(dataset, "label", labels)
+    booster = LightGBM.LGBM_BoosterCreate(dataset, verbosity)
+
+    # update learning 20 times
+    for _ in [1:20;]
+        finished = LightGBM.LGBM_BoosterUpdateOneIter(booster)
+    end
+
+    # Act and Assert
+    for n in reverse([1:20;])
+        @test LightGBM.LGBM_BoosterGetCurrentIteration(booster) == n
+        LightGBM.LGBM_BoosterRollbackOneIter(booster)
+    end
 
 end
 

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -178,7 +178,12 @@ end
     # Act and Assert
     for n in reverse([1:20;])
         @test LightGBM.LGBM_BoosterGetCurrentIteration(booster) == n
+        model_string = LightGBM.LGBM_BoosterSaveModelToString(booster)
+        model_loaded_from_string = LightGBM.LGBM_BoosterLoadModelFromString(model_string)
+        @test LightGBM.LGBM_BoosterGetCurrentIteration(model_loaded_from_string) == n
+
         LightGBM.LGBM_BoosterRollbackOneIter(booster)
+
     end
 
 end

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -180,7 +180,9 @@ end
         @test LightGBM.LGBM_BoosterGetCurrentIteration(booster) == n
 
         model_string = LightGBM.LGBM_BoosterSaveModelToString(booster)
+        # pull out the line in the string on tree sizes (only one line should be return, so take the first element)
         tree_sizes_in_string = match(r"\ntree_sizes=(.*)\n", model_string)[1]
+        # tree sizes are delimited by space, so we can count the number of trees easily
         @test length(split(tree_sizes_in_string, " ")) == n
 
         model_loaded_from_string = LightGBM.LGBM_BoosterLoadModelFromString(model_string)

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -178,7 +178,11 @@ end
     # Act and Assert
     for n in reverse([1:20;])
         @test LightGBM.LGBM_BoosterGetCurrentIteration(booster) == n
+
         model_string = LightGBM.LGBM_BoosterSaveModelToString(booster)
+        tree_sizes_in_string = match(r"\ntree_sizes=(.*)\n", model_string)[1]
+        @test length(split(tree_sizes_in_string, " ")) == n
+
         model_loaded_from_string = LightGBM.LGBM_BoosterLoadModelFromString(model_string)
         @test LightGBM.LGBM_BoosterGetCurrentIteration(model_loaded_from_string) == n
 

--- a/test/mlj/user_report.jl
+++ b/test/mlj/user_report.jl
@@ -25,7 +25,7 @@ y = randn(nrows)
     report = LightGBM.MLJInterface.user_fitreport(estimator, metrics)
 
     # check types (loosely)
-    @test report isa NamedTuple{(:training_metrics, :importance)}
+    @test report isa NamedTuple{(:training_metrics, :importance, :best_iter)}
     @test report.training_metrics isa Dict
     @test report.importance isa NamedTuple{(:gain, :split)}
     # check value properties
@@ -34,12 +34,12 @@ y = randn(nrows)
     @test length(report.training_metrics["training"]["l2"]) == 2
 
     # continue for another 3 iterations, and check that the metrics lengths update properly
-    new_metrics = LightGBM.train!(estimator, 3, String[], -1, LightGBM.Dates.now())
+    new_results = LightGBM.train!(estimator, 3, String[], -1, LightGBM.Dates.now())
 
-    new_report = LightGBM.MLJInterface.user_fitreport(estimator, metrics, new_metrics)
+    new_report = LightGBM.MLJInterface.user_fitreport(estimator, metrics["metrics"], new_results)
 
     # repeat all same tests except training metrics is now 3, not 1
-    @test new_report isa NamedTuple{(:training_metrics, :importance)}
+    @test new_report isa NamedTuple{(:training_metrics, :importance, :best_iter)}
     @test new_report.training_metrics isa Dict
     @test new_report.importance isa NamedTuple{(:gain, :split)}
     # check value properties
@@ -56,7 +56,7 @@ y = randn(nrows)
     @test length(report.training_metrics["training"]["l2"]) == 3
 
     new_freq_metrics = LightGBM.train!(new_estimator, 7, String[], -1, LightGBM.Dates.now())
-    new_report = LightGBM.MLJInterface.user_fitreport(new_estimator, freq_metrics, new_freq_metrics)
+    new_report = LightGBM.MLJInterface.user_fitreport(new_estimator, freq_metrics["metrics"], new_freq_metrics)
     @test length(new_report.training_metrics["training"]["l2"]) == 10
 
 end


### PR DESCRIPTION
This PR addresses some issues related early stopping:

- The `best_iter` is a new key in the output of `fit!`/`train!` that captures the best iteration if early stopping is enabled (also added to the MLJ report)
- The original output is nested inside a dict key "metrics"
- We have added a `truncate_booster` Boolean flag (defaults to true) in `fit!`/`train!` that determines whether or not a model should be truncated to the best_iteration
- For running in MLJ, the `truncate_booster` flag can be declared when constructing the `LightGBM.MLJInterface.LGBMClassifier`, which will be passed to the `fit!`/`train!` methods when called