### PR TITLE
enable custom compiled lightgbm package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           version: '1.4'
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.build(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           version: '1.4'
       - name: Build package
-        run: julia --project -e 'using Pkg; Pkg.build()'
-      - name: Build and deploy
+        run: julia --project -e 'using Pkg; Pkg.build(); Pkg.instantiate()'
+      - name: Build docs and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,8 @@ jobs:
           version: '1.4'
       - name: Build package
         run: julia --project -e 'using Pkg; Pkg.build(); Pkg.instantiate()'
+      - name: Instantiate docs
+        run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build docs and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,8 +51,10 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.4'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.build(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build package
+        run: julia --project -e 'using Pkg; Pkg.build()'
+      - name: Get docs and instantiate
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,6 @@ jobs:
           version: '1.4'
       - name: Build package
         run: julia --project -e 'using Pkg; Pkg.build()'
-      - name: Get docs and instantiate
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,10 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: '1.4'
-      - name: Build package
+      - name: Build package to grab binary
         run: julia --project -e 'using Pkg; Pkg.build(); Pkg.instantiate()'
       - name: Instantiate docs
-        run: julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build docs and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.3"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.4.3"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The interface models are generally passed to `MLJBase.fit` or `MLJBase.machine`
 and integrated as part of a larger MLJ pipeline. [An example is provided](https://alan-turing-institute.github.io/DataScienceTutorials.jl/end-to-end/boston-lgbm/)
 
 # Custom LightGBM binaries
-Though this package comes with a precompiled binary (`lib_lightgbm.so` for linux, `lib_lightgbm.dylib` for macos, `lib_lightgbm.dll` for windows), a custom binary can be used with this package (we use `Libdl.dlopen` to do this). In order to do so, either:
+Though this package comes with a precompiled binary (`lib_lightgbm.so` for linux, `lib_lightgbm.dylib` for macos, `lib_lightgbm.dll` for windows, refer to [Microsoft's LightGBM release page](https://github.com/microsoft/LightGBM/releases)), a custom binary can be used with this package (we use `Libdl.dlopen` to do this). In order to do so, either:
 
   - Add the directory of your custom binary to the `Libdl.DL_LOAD_PATH` before calling `import LightGBM`, e.g.
       ```
@@ -141,7 +141,7 @@ Though this package comes with a precompiled binary (`lib_lightgbm.so` for linux
       ```
   - Specify the directory of your custom binary in the environment variables `LD_LIBRARY_PATH` (for linux), `DYLD_LIBRARY_PATH` (macos), `PATH` (windows), or place the custom binary file in the system search path
 
-Note: `Libdl.DL_LOAD_PATH` will be first searched and used, then the system library paths. If no binaries are found, the programme will fallback to using the precompiled binary
+Note: `Libdl.DL_LOAD_PATH` will be first searched and used, then the system library paths. If no binaries are found, the program will fallback to using the precompiled binary
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -129,12 +129,19 @@ The interface models are generally passed to `MLJBase.fit` or `MLJBase.machine`
 and integrated as part of a larger MLJ pipeline. [An example is provided](https://alan-turing-institute.github.io/DataScienceTutorials.jl/end-to-end/boston-lgbm/)
 
 # Custom LightGBM binaries
-Though this package comes with a precompiled binary, a custom binary can be used with this package if it is detectable in the system directories (we use `Libdl.dlopen` to do this). In order to use your custom binary:
-- For linux/OSX, either:
-    - Specify the directory of your binary in the environment variable `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`, or
-	- Have the `lib_lightgbm.so`/`lib_lightgbm.dylib` file in the system search path, e.g. `/lib`, `/usr/lib`, or modify `/etc/ld.so.conf` to include the directory of the file
-- For windows:
-    - Extend your `PATH` env variable to include the directory that contains your own `lib_lightgbm.dll` file if this is not already in the existing `PATH` directories
+Though this package comes with a precompiled binary (`lib_lightgbm.so` for linux, `lib_lightgbm.dylib` for macos, `lib_lightgbm.dll` for windows), a custom binary can be used with this package (we use `Libdl.dlopen` to do this). In order to do so, either:
+
+  - Add the directory of your custom binary to the `Libdl.DL_LOAD_PATH` before calling `import LightGBM`, e.g.
+      ```
+      import Libdl
+      push!(Libdl.DL_LOAD_PATH, "/path/to/your/lib_lightgbm/directory")
+
+      import LightGBM
+      ...
+      ```
+  - Specify the directory of your custom binary in the environment variables `LD_LIBRARY_PATH` (for linux), `DYLD_LIBRARY_PATH` (macos), `PATH` (windows), or place the custom binary file in the system search path
+
+Note: `Libdl.DL_LOAD_PATH` will be first searched and used, then the system library paths. If no binaries are found, the programme will fallback to using the precompiled binary
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ And these have the same interface parameters as the [estimators](#estimators)
 The interface models are generally passed to `MLJBase.fit` or `MLJBase.machine`
 and integrated as part of a larger MLJ pipeline. [An example is provided](https://alan-turing-institute.github.io/DataScienceTutorials.jl/end-to-end/boston-lgbm/)
 
+# Custom LightGBM binaries
+Though this package comes with a precompiled binary, a custom binary can be used with this package if it is detectable in the system directories (we use `Libdl.dlopen` to do this). In order to use your custom binary:
+- For linux/OSX, either:
+    - Specify the directory of your binary in the environment variable `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`, or
+	- Have the `lib_lightgbm.so`/`lib_lightgbm.dylib` file in the system search path, e.g. `/lib`, `/usr/lib`, or modify `/etc/ld.so.conf` to include the directory of the file
+- For windows:
+    - Extend your `PATH` env variable to include the directory that contains your own `lib_lightgbm.dll` file if this is not already in the existing `PATH` directories
+
 ## Contributors ✨
 
 The list of our Contributors can be found [here](CONTRIBUTORS.md).

--- a/src/LightGBM.jl
+++ b/src/LightGBM.jl
@@ -1,11 +1,14 @@
 module LightGBM
 
 using Dates
-using Logging
 import Base
 import Libdl
 import StatsBase
 import Libdl
+
+struct LibraryNotFoundError <: Exception
+    msg::String
+end
 
 
 function find_library(library_name::String, custom_paths::Vector{String})
@@ -22,7 +25,7 @@ function find_library(library_name::String, custom_paths::Vector{String})
     end
 
     if output == ""
-        @error("$(library_name) not found. Please ensure this library is either in system dirs or the dedicated paths: $(custom_paths)")
+        throw(LibraryNotFoundError("$(library_name) not found. Please ensure this library is either in system dirs or the dedicated paths: $(custom_paths)"))
     end
 
     return output

--- a/src/LightGBM.jl
+++ b/src/LightGBM.jl
@@ -1,13 +1,39 @@
 module LightGBM
 
 using Dates
-
+using Logging
 import Base
 import Libdl
 import StatsBase
+import Libdl
 
-# we build it so we can assert it is present...
-const LGBM_library = abspath(joinpath(@__DIR__, "lib_lightgbm.$(Libdl.dlext)"))
+struct LibraryNotFoundError <: Exception
+    msg::String
+end
+
+
+function find_library(library_name::String, custom_paths::Vector{String})
+
+    # Search system filedirs first, returns empty string if not found
+    output = Libdl.find_library(library_name)
+
+    if output == ""
+        # try specified paths
+        @info("$(library_name) not found in system dirs, trying fallback")
+        output = Libdl.find_library(library_name, custom_paths)
+    else
+        @info("$(library_name) found in system dirs!")
+    end
+
+    if output == ""
+        throw(LibraryNotFoundError("$(library_name) not found. Please ensure this library is either in system dirs or the dedicated paths: $(custom_paths)"))
+    end
+
+    return output
+
+end
+
+const LGBM_library = find_library("lib_lightgbm", [@__DIR__])
 
 include("wrapper.jl")
 include("estimators.jl")

--- a/src/LightGBM.jl
+++ b/src/LightGBM.jl
@@ -7,10 +7,6 @@ import Libdl
 import StatsBase
 import Libdl
 
-struct LibraryNotFoundError <: Exception
-    msg::String
-end
-
 
 function find_library(library_name::String, custom_paths::Vector{String})
 
@@ -26,7 +22,7 @@ function find_library(library_name::String, custom_paths::Vector{String})
     end
 
     if output == ""
-        throw(LibraryNotFoundError("$(library_name) not found. Please ensure this library is either in system dirs or the dedicated paths: $(custom_paths)"))
+        @error("$(library_name) not found. Please ensure this library is either in system dirs or the dedicated paths: $(custom_paths)")
     end
 
     return output

--- a/test/basic/test_lightgbm.jl
+++ b/test/basic/test_lightgbm.jl
@@ -1,0 +1,97 @@
+module TestLightGBM
+
+import Libdl
+using LightGBM
+using Test
+
+src_dir = abspath(joinpath(@__DIR__, "..", "..", "src"))
+
+# These set of tests use common libraries of each system to test `find_library` without having to modify env variables
+function setup_env()
+    output = Dict()
+
+    if Sys.islinux()
+        output["sample_lib"] = "libcrypt"
+    elseif Sys.isunix()
+        output["sample_lib"] = "libevent"
+    elseif Sys.iswindows()
+        output["sample_lib"] = "netmsg"
+    end
+
+    output["ref_path"] = joinpath(src_dir, "lib_lightgbm.$(Libdl.dlext)")
+    output["custom_fixture_path"] = joinpath(src_dir, "$(output["sample_lib"]).$(Libdl.dlext)")
+    output["lib_not_on_sys_fixture_path"] = joinpath(src_dir, "lib_not_on_sys.$(Libdl.dlext)")
+
+    return output
+
+end
+
+function teardown(settings::Dict)
+
+    rm(settings["custom_fixture_path"], force=true)
+    rm(settings["lib_not_on_sys_fixture_path"], force=true)
+
+    return nothing
+
+end
+
+@testset "find_library" begin
+
+    @testset "find_library works with no system lib" begin
+
+        # Arrange
+        settings = setup_env()
+        cp(settings["ref_path"], settings["lib_not_on_sys_fixture_path"]) # fake file copied from lightgbm
+
+        # Act
+        output = LightGBM.find_library("lib_not_on_sys", [src_dir])
+
+        # Assert
+        @test output == joinpath(src_dir, "lib_not_on_sys") # custom path detected (without extension)
+
+        teardown(settings)
+    end
+
+    @testset "find_library finds system lib first" begin
+
+        # Arrange
+        settings = setup_env()
+        cp(settings["ref_path"], settings["custom_fixture_path"]) # fake file copied from lightgbm
+
+        # Act
+        output = LightGBM.find_library(settings["sample_lib"], [src_dir])
+
+        # Assert
+        @test output == settings["sample_lib"] # sys lib detected
+
+        teardown(settings)
+    end
+
+    @testset "find_library finds system lib" begin
+
+        # Arrange
+        settings = setup_env()
+
+        # Act
+        output = LightGBM.find_library(settings["sample_lib"], [src_dir]) # sample_lib should only exist in syspath
+
+        # Assert
+        @test output == settings["sample_lib"]
+
+        teardown(settings)
+    end
+
+    @testset "find_library throws error if cannot find lib" begin
+
+        # Arrange
+        settings = setup_env()
+
+        # Act and assert
+        @test_throws LightGBM.LibraryNotFoundError LightGBM.find_library("lib_that_simply_doesnt_exist", [src_dir])
+
+        teardown(settings)
+
+    end
+end
+
+end # module

--- a/test/basic/test_lightgbm.jl
+++ b/test/basic/test_lightgbm.jl
@@ -13,7 +13,7 @@ function setup_env()
     if Sys.islinux()
         output["sample_lib"] = "libcrypt"
     elseif Sys.isunix()
-        output["sample_lib"] = "libevent"
+        output["sample_lib"] = "libpython"
     elseif Sys.iswindows()
         output["sample_lib"] = "netmsg"
     end
@@ -81,13 +81,15 @@ end
         teardown(settings)
     end
 
-    @testset "find_library throws error if cannot find lib" begin
+    @testset "find_library returns empty and logs error" begin
 
         # Arrange
         settings = setup_env()
 
         # Act and assert
-        @test_throws LightGBM.LibraryNotFoundError LightGBM.find_library("lib_that_simply_doesnt_exist", [src_dir])
+        @test (
+            @test_logs (:error,) match_mode=:any LightGBM.find_library("lib_that_simply_doesnt_exist", [src_dir])
+        ) == ""
 
         teardown(settings)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,10 @@ end
         include(joinpath("basic", "test_search_cv.jl"))
     end
 
+    @testset "LightGBM" begin
+        include(joinpath("basic", "test_lightgbm.jl"))
+    end
+
 end
 
 @testset "Integration tests" begin


### PR DESCRIPTION
enable using custom lightgbm packages by utilising Libdl to search for system paths (and use if available) before falling back to using the default precompiled lightgbm library