### PR TITLE
Release v0.5.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LightGBM"
 uuid = "7acf609c-83a4-11e9-1ffb-b912bcd3b04a"
-version = "0.4.3"
+version = "0.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
v0.5.0 Release
- Expanded compatibility range for MLJModelInterface
- Metrics report includes best iteration number (regardless of whether early stopping on or not)
  - Also fixed a bug with early stopping where the model was not truncated
  - Made truncation optional via a `fit!` parameter, `truncate_booster`, default true
- Added support for `feature_pre_filter` parameter
- Updated `min_sum_hessian_in_leaf` default value to match LightGBM default, 1e-3
- Added mechanism to find lib_lightgbm from system search paths, allowing users to provide their own version of the library.
  - The bundled one is still included if the user does not provide.