### PR TITLE
Fix parameter passing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LightGBM"
 uuid = "7acf609c-83a4-11e9-1ffb-b912bcd3b04a"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/search_cv.jl
+++ b/src/search_cv.jl
@@ -36,7 +36,7 @@ function search_cv(
     truncate_booster::Bool=true
 ) where {TX<:Real,Ty<:Real}
 
-    ds_parameters = stringifyparams(estimator, DATASETPARAMS)
+    ds_parameters = stringifyparams(estimator; verbosity=verbosity)
     full_ds = LGBM_DatasetCreateFromMat(X, ds_parameters)
     LGBM_DatasetSetField(full_ds, "label", y)
                                                                     

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,19 +1,3 @@
-const DATASETPARAMS = [
-    :is_sparse, :max_bin, :bin_construct_sample_cnt, :data_random_seed,
-    :categorical_feature, :use_missing, :feature_pre_filter
-]
-
-const BOOSTERPARAMS = [
-    :application, :boosting, :learning_rate, :num_leaves, :max_depth, :tree_learner,
-    :num_threads, :histogram_pool_size, :min_data_in_leaf, :min_sum_hessian_in_leaf, :max_delta_step,
-    :max_bin, :lambda_l1, :lambda_l2, :min_gain_to_split, :feature_fraction, :feature_fraction_bynode,
-    :feature_fraction_seed, :bagging_fraction, :pos_bagging_fraction, :neg_bagging_fraction,
-    :bagging_freq, :bagging_seed, :early_stopping_round, :extra_trees, :extra_seed, :sigmoid, :alpha,
-    :is_unbalance, :boost_from_average, :scale_pos_weight, :drop_rate, :max_drop, :skip_drop,
-    :xgboost_dart_mode, :uniform_drop,:drop_seed, :top_rate, :other_rate, :min_data_per_group, :max_cat_threshold, :cat_l2,
-    :cat_smooth, :metric, :is_training_metric, :ndcg_at, :num_machines, :local_listen_port, :time_out, :machine_list_file,
-    :num_class, :device_type, :force_col_wise, :force_row_wise,
-]
 
 const INDEXPARAMS = [:categorical_feature]
 

--- a/test/basic/test_fit.jl
+++ b/test/basic/test_fit.jl
@@ -62,7 +62,7 @@ end
         metric = ["auc"],
     )
 
-    bst_parameters = LightGBM.stringifyparams(estimator, LightGBM.BOOSTERPARAMS) * " verbosity=-1"
+    bst_parameters = LightGBM.stringifyparams(estimator; verbosity=-1)
     estimator.booster = LightGBM.LGBM_BoosterCreate(train_dataset, bst_parameters)
     LightGBM.LGBM_BoosterAddValidData(estimator.booster, test_dataset)
 
@@ -85,7 +85,7 @@ end
         metric = ["auc", "l2"],
     )
 
-    bst_parameters = LightGBM.stringifyparams(estimator, LightGBM.BOOSTERPARAMS) * " verbosity=-1"
+    bst_parameters = LightGBM.stringifyparams(estimator; verbosity=-1)
     estimator.booster = LightGBM.LGBM_BoosterCreate(train_dataset, bst_parameters)
     LightGBM.LGBM_BoosterAddValidData(estimator.booster, test_dataset)
     LightGBM.LGBM_BoosterAddValidData(estimator.booster, test2_dataset)
@@ -114,7 +114,7 @@ end
         metric = ["auc", "l2"],
     )
 
-    bst_parameters = LightGBM.stringifyparams(estimator, LightGBM.BOOSTERPARAMS) * " verbosity=-1"
+    bst_parameters = LightGBM.stringifyparams(estimator; verbosity=-1)
     estimator.booster = LightGBM.LGBM_BoosterCreate(train_dataset, bst_parameters)
     LightGBM.LGBM_BoosterAddValidData(estimator.booster, test_dataset)
     LightGBM.LGBM_BoosterAddValidData(estimator.booster, test2_dataset)
@@ -168,7 +168,7 @@ end
         early_stopping_round = 0 # default value, but stating explicitly to test!
     )
     
-    bst_parameters = LightGBM.stringifyparams(estimator, LightGBM.BOOSTERPARAMS) * " verbosity=-1"
+    bst_parameters = LightGBM.stringifyparams(estimator; verbosity=-1)
     estimator.booster = LightGBM.LGBM_BoosterCreate(train_dataset, bst_parameters)
     LightGBM.LGBM_BoosterAddValidData(estimator.booster, test_dataset)
 
@@ -208,7 +208,7 @@ Criteria: early_stopping should kick in on round 6
         early_stopping_round = 5
     )
     
-    bst_parameters = LightGBM.stringifyparams(estimator, LightGBM.BOOSTERPARAMS) * " verbosity=-1"
+    bst_parameters = LightGBM.stringifyparams(estimator; verbosity=-1)
     estimator.booster = LightGBM.LGBM_BoosterCreate(train_dataset, bst_parameters)
     LightGBM.LGBM_BoosterAddValidData(estimator.booster, test_dataset)
 
@@ -269,7 +269,7 @@ end
     verbosity = "verbose=-1"
    
     # Act
-    output = LightGBM.fit!(estimator, train_dataset, test_dataset, truncate_booster=true)
+    output = LightGBM.fit!(estimator, train_dataset, test_dataset; truncate_booster=true, verbosity=-1)
 
     # Assert
     eval_metrics_run_count = length(output["metrics"]["test_1"]["auc"]) 
@@ -290,7 +290,7 @@ end
     verbosity = "verbose=-1"
    
     # Act
-    output = LightGBM.fit!(estimator, train_dataset, test_dataset, truncate_booster=false)
+    output = LightGBM.fit!(estimator, train_dataset, test_dataset; truncate_booster=false, verbosity=-1)
 
     # Assert
     eval_metrics_run_count = length(output["metrics"]["test_1"]["auc"]) 
@@ -312,7 +312,7 @@ end
     verbosity = "verbose=-1"
    
     # Act
-    output = LightGBM.fit!(estimator, train_dataset, test_dataset, truncate_booster=true)
+    output = LightGBM.fit!(estimator, train_dataset, test_dataset; truncate_booster=true, verbosity=-1)
 
     # Assert
     eval_metrics_run_count = length(output["metrics"]["test_1"]["auc"]) 

--- a/test/basic/test_utils.jl
+++ b/test/basic/test_utils.jl
@@ -10,7 +10,7 @@ y_train_regression = rand(1000)
 @testset "stringifyparams -- convert to zero-based" begin
     indices = [1, 3, 5, 7, 9]
     classifier = LightGBM.LGBMClassification(categorical_feature = indices)
-    ds_parameters = LightGBM.stringifyparams(classifier, LightGBM.DATASETPARAMS)
+    ds_parameters = LightGBM.stringifyparams(classifier; verbosity=-1)
 
     expected = "categorical_feature=0,2,4,6,8"
     @test occursin(expected, ds_parameters)
@@ -21,7 +21,7 @@ end
 @testset "loadmodel predicts same as original model -- regression" begin
     # Arrange
     estimator = LightGBM.LGBMRegression(objective = "regression")
-    LightGBM.fit!(estimator, X_train, y_train_regression)
+    LightGBM.fit!(estimator, X_train, y_train_regression; verbosity=-1)
     expected_prediction = predict(estimator, X_train)
     # Save the fitted model.
     model_filename = joinpath(@__DIR__, "fixture.model")
@@ -44,7 +44,7 @@ end
 @testset "loadmodel predicts same as original model -- binary" begin
     # Arrange
     estimator = LightGBM.LGBMClassification(objective = "binary", num_class = 1)
-    LightGBM.fit!(estimator, X_train, y_train_binary)
+    LightGBM.fit!(estimator, X_train, y_train_binary; verbosity=-1)
     expected_prediction = predict(estimator, X_train)
     # Save the fitted model.
     model_filename = joinpath(@__DIR__, "fixture.model")
@@ -75,7 +75,7 @@ end
         num_leaves = 100,
         metric = ["auc", "binary_logloss"]
     )
-    LightGBM.fit!(estimator, X_train, y_train_regression)
+    LightGBM.fit!(estimator, X_train, y_train_regression; verbosity=-1)
     expected_prediction = predict(estimator, X_train)
     # Save the fitted model.
     model_filename = joinpath(@__DIR__, "fixture.model")
@@ -109,7 +109,7 @@ end
         num_class = 1,
         metric = ["auc", "binary_logloss"]
     )
-    LightGBM.fit!(estimator, X_train, y_train_binary)
+    LightGBM.fit!(estimator, X_train, y_train_binary; verbosity=-1)
     expected_prediction = predict(estimator, X_train)
     # Save the fitted model.
     model_filename = joinpath(@__DIR__, "fixture.model")


### PR DESCRIPTION
It seems like some parameters were not being passed to dataset or booster.

Rather than trying to fix this by hand, I took advantage of the fact that LightGBM doesn't seem to warn if you pass all the parameters to both constructs, so I updated `stringifyparams` to just ignore the `booster` and `model` fields

I also took the opportunity to give it a kwarg to add verbosity and fix verbosity passing everywhere -- finally tests don't vomit output everywhere.