### PR TITLE
Extend compat MLJModelInterface = "^0.3.6,^0.4,^1.0"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-MLJModelInterface = "^0.3.6,^0.4"
+MLJModelInterface = "^0.3.6,^0.4,^1.0"
 StatsBase = "^0.32,^0.33"
 julia = "1.0"
 


### PR DESCRIPTION
MLJModelInterface 1.0 is identical to 0.4, so hopefully no surprises here.

BTW I suggest the developers add CompatHelper github action to automatically generate PR's like this one: https://juliaregistries.github.io/CompatHelper.jl/dev/