### PR TITLE
Release v0.5.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LightGBM"
 uuid = "7acf609c-83a4-11e9-1ffb-b912bcd3b04a"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
v0.5.2 Release:

- Expanded compatibility range for MLJModelInterface "^0.3.6,^0.4,^1.0"
- Added more GPU tuning parameters:

```
    gpu_use_dp::Bool
    gpu_platform_id::Int
    gpu_device_id::Int
    num_gpu::Int
```

- Fixed precompile caching of the library path
