### PR TITLE
small fix to custom objective test

### DIFF
--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -196,7 +196,7 @@ end
 
     dataset = LightGBM.LGBM_DatasetCreateFromMat(mymat, verbosity)
     LightGBM.LGBM_DatasetSetField(dataset, "label", labels)
-    booster = LightGBM.LGBM_BoosterCreate(dataset, "objective=multiclass num_class=$(num_class) $verbosity")
+    booster = LightGBM.LGBM_BoosterCreate(dataset, "objective=none num_class=$(num_class) $verbosity")
 
     finished = LightGBM.LGBM_BoosterUpdateOneIterCustom(booster, randn(numdata*num_class), rand(numdata*num_class))
     pred1 = LightGBM.LGBM_BoosterGetPredict(booster, 0)


### PR DESCRIPTION
When using a custom objective it is probably better to put `objective=none` rather than `objective=multiclass` (the python package pops the objective and replaces it with none: https://github.com/microsoft/LightGBM/blob/67b4205c8043326553e294fa2c01ad1189784631/python-package/lightgbm/engine.py#L168) 