### PR TITLE
Don't try find_library tests if the system doesn't satisfy the assumptions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1.7']
+        version: ['1.6', '1.7', '1.8']
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7']
+        version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8']
         os:  [windows-latest, ubuntu-latest, macOS-latest]
         arch:
           - x64

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LightGBM"
 uuid = "7acf609c-83a4-11e9-1ffb-b912bcd3b04a"
-version = "0.5.2"
+version = "0.6.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/basic/test_lightgbm.jl
+++ b/test/basic/test_lightgbm.jl
@@ -17,6 +17,8 @@ function setup_env()
     loaded = Libdl.dllist()
     # get all the ones which just have the system extension and no funny business
     withext = loaded[endswith.(loaded, Ref(Libdl.dlext))]
+    # Some versions of LLVM are ... weird ... in that they don't like being double loaded. Use something else
+    withext = withext[.!occursin.(Ref("LLVM"), withext)]
     # get the libname without prefix and extension
     withoutext = libname.(withext)
     # check which are loadable (or findable by find_library, this is WILD if they're not all found)
@@ -24,8 +26,6 @@ function setup_env()
     # get the first one matching or nothing
     libidx = findfirst(libnames .== withoutext)
     borked = libidx == nothing
-
-
 
     output = Dict()
     output["sample_lib"] = ""

--- a/test/basic/test_lightgbm.jl
+++ b/test/basic/test_lightgbm.jl
@@ -6,19 +6,36 @@ using Test
 
 src_dir = abspath(joinpath(@__DIR__, "..", "..", "src"))
 
+# little helper to get base libnames
+libname(x) = first(splitext(basename(x)))
+
 # These set of tests use common libraries of each system to test `find_library` without having to modify env variables
 function setup_env()
+
+    # get libs that are definitely present and linkable for tests (with just system extension)
+    # by virtue of being loaded
+    loaded = Libdl.dllist()
+    # get all the ones which just have the system extension and no funny business
+    withext = loaded[endswith.(loaded, Ref(Libdl.dlext))]
+    # get the libname without prefix and extension
+    withoutext = libname.(withext)
+    # check which are loadable (or findable by find_library, this is WILD if they're not all found)
+    libnames = Libdl.find_library.(withoutext)
+    # get the first one matching or nothing
+    libidx = findfirst(libnames .== withoutext)
+    borked = libidx == nothing
+
+
+
     output = Dict()
+    output["sample_lib"] = ""
+    output["linkable_path"] = ""
 
-    if Sys.islinux()
-        output["sample_lib"] = "libcrypt"
-    elseif Sys.isunix()
-        output["sample_lib"] = "libpython"
-    elseif Sys.iswindows()
-        output["sample_lib"] = "netmsg"
+    if !borked
+        output["sample_lib"] = withoutext[libidx]
+        # fullpath of a linkable lib to copy off the sys path
+        output["linkable_path"] = withext[libidx]
     end
-
-    output["ref_lib_lightgbm_path"] = joinpath(src_dir, "lib_lightgbm.$(Libdl.dlext)")
 
     # where to create a fixture library file (custom path) where such library exists in the syspath
     output["custom_fixture_path"] = joinpath(src_dir, "$(output["sample_lib"]).$(Libdl.dlext)")
@@ -26,7 +43,7 @@ function setup_env()
     # where to create a fixture library file (custom path) where such library does NOT exist in the syspath
     output["lib_not_on_sys_fixture_path"] = joinpath(src_dir, "lib_not_on_sys.$(Libdl.dlext)")
 
-    return output
+    return output, borked
 
 end
 
@@ -44,14 +61,20 @@ end
     @testset "find_library works with no system lib" begin
 
         # Arrange
-        settings = setup_env()
-        cp(settings["ref_lib_lightgbm_path"], settings["lib_not_on_sys_fixture_path"]) # fake file copied from lightgbm
+        settings, isborked = setup_env()
+        if !isborked
+            cp(settings["linkable_path"], settings["lib_not_on_sys_fixture_path"], force=true, follow_symlinks=true)
+        end
 
         # Act
         output = LightGBM.find_library("lib_not_on_sys", [src_dir])
 
         # Assert
-        @test output == joinpath(src_dir, "lib_not_on_sys") # custom path detected (without extension)
+        if !isborked
+            @test output == joinpath(src_dir, "lib_not_on_sys") # custom path detected (without extension)
+        else
+            @test_broken output == joinpath(src_dir, "lib_not_on_sys")
+        end
 
         teardown(settings)
     end
@@ -59,14 +82,20 @@ end
     @testset "find_library finds system lib first" begin
 
         # Arrange
-        settings = setup_env()
-        cp(settings["ref_lib_lightgbm_path"], settings["custom_fixture_path"]) # fake file copied from lightgbm
+        settings, isborked = setup_env()
+        if !isborked
+            cp(settings["linkable_path"], settings["custom_fixture_path"], force=true, follow_symlinks=true)
+        end
 
         # Act
         output = LightGBM.find_library(settings["sample_lib"], [src_dir])
 
         # Assert
-        @test output == settings["sample_lib"] # sys lib detected
+        if !isborked
+            @test output == settings["sample_lib"] # sys lib detected
+        else
+            @test_broken output == settings["sample_lib"]
+        end
 
         teardown(settings)
     end
@@ -74,7 +103,7 @@ end
     @testset "find_library finds system lib" begin
 
         # Arrange
-        settings = setup_env()
+        settings, isborked = setup_env()
 
         # Act
         output = LightGBM.find_library(settings["sample_lib"], [src_dir]) # library should only exist in syspath, not custom path
@@ -88,7 +117,7 @@ end
     @testset "find_library returns empty and logs error" begin
 
         # Arrange
-        settings = setup_env()
+        settings, _ = setup_env()
 
         # Act and assert
         @test_throws LightGBM.LibraryNotFoundError LightGBM.find_library("lib_that_simply_doesnt_exist", [src_dir])

--- a/test/basic/test_lightgbm.jl
+++ b/test/basic/test_lightgbm.jl
@@ -6,44 +6,41 @@ using Test
 
 src_dir = abspath(joinpath(@__DIR__, "..", "..", "src"))
 
-# little helper to get base libnames
-libname(x) = first(splitext(basename(x)))
-
 # These set of tests use common libraries of each system to test `find_library` without having to modify env variables
 function setup_env()
 
-    # get libs that are definitely present and linkable for tests (with just system extension)
-    # by virtue of being loaded
-    loaded = Libdl.dllist()
-    # get all the ones which just have the system extension and no funny business
-    withext = loaded[endswith.(loaded, Ref(Libdl.dlext))]
-    # Some versions of LLVM are ... weird ... in that they don't like being double loaded. Use something else
-    withext = withext[.!occursin.(Ref("LLVM"), withext)]
-    # get the libname without prefix and extension
-    withoutext = libname.(withext)
-    # check which are loadable (or findable by find_library, this is WILD if they're not all found)
-    libnames = Libdl.find_library.(withoutext)
-    # get the first one matching or nothing
-    libidx = findfirst(libnames .== withoutext)
-    borked = libidx == nothing
-
     output = Dict()
     output["sample_lib"] = ""
-    output["linkable_path"] = ""
 
-    if !borked
-        output["sample_lib"] = withoutext[libidx]
-        # fullpath of a linkable lib to copy off the sys path
-        output["linkable_path"] = withext[libidx]
+    if Sys.islinux()
+        output["sample_lib"] = "libcrypt"
+    elseif Sys.isunix()
+        output["sample_lib"] = "libpython"
+    elseif Sys.iswindows()
+        output["sample_lib"] = "netmsg"
     end
 
-    # where to create a fixture library file (custom path) where such library exists in the syspath
-    output["custom_fixture_path"] = joinpath(src_dir, "$(output["sample_lib"]).$(Libdl.dlext)")
+    loaded = Libdl.find_library(output["sample_lib"])
+    # If we can't load the expected sample library treat this as a broken system for the purpose of tests
+    # it isn't important these tests pass on all systems,
+    # because we had to be able to load a LightGBM library at all to run them
+    # and sometimes they fail and cause user consternation because assumptions aren't satisfied
+    broken_system = loaded == ""
+    fullpath = Libdl.dlpath(loaded)
 
-    # where to create a fixture library file (custom path) where such library does NOT exist in the syspath
-    output["lib_not_on_sys_fixture_path"] = joinpath(src_dir, "lib_not_on_sys.$(Libdl.dlext)")
+    if !broken_system
+        # fullpath of a linkable lib to copy off the sys path
+        output["linkable_path"] = fullpath
+        # where to create a fixture library file (custom path) where such library exists in the syspath
+        output["custom_fixture_path"] = joinpath(src_dir, "$(output["sample_lib"]).$(Libdl.dlext)")
+        # where to create a fixture library file (custom path) where such library does NOT exist in the syspath
+        output["lib_not_on_sys_fixture_path"] = joinpath(src_dir, "lib_not_on_sys.$(Libdl.dlext)")
+        # move some files for the tests
+        cp(output["linkable_path"], output["lib_not_on_sys_fixture_path"], force=true, follow_symlinks=true)
+        cp(output["linkable_path"], output["custom_fixture_path"], force=true, follow_symlinks=true)
+    end
 
-    return output, borked
+    return output, broken_system
 
 end
 
@@ -58,73 +55,40 @@ end
 
 @testset "find_library" begin
 
+    # Arrange -- once only because it isn't necessary to repeat this over and over
+    settings, broken_system = setup_env()
+
     @testset "find_library works with no system lib" begin
-
-        # Arrange
-        settings, isborked = setup_env()
-        if !isborked
-            cp(settings["linkable_path"], settings["lib_not_on_sys_fixture_path"], force=true, follow_symlinks=true)
-        end
-
         # Act
         output = LightGBM.find_library("lib_not_on_sys", [src_dir])
 
         # Assert
-        if !isborked
+        if !broken_system
             @test output == joinpath(src_dir, "lib_not_on_sys") # custom path detected (without extension)
         else
             @test_broken output == joinpath(src_dir, "lib_not_on_sys")
         end
-
-        teardown(settings)
     end
 
-    @testset "find_library finds system lib first" begin
-
-        # Arrange
-        settings, isborked = setup_env()
-        if !isborked
-            cp(settings["linkable_path"], settings["custom_fixture_path"], force=true, follow_symlinks=true)
-        end
-
+    @testset "find_library finds system lib before fallback" begin
         # Act
         output = LightGBM.find_library(settings["sample_lib"], [src_dir])
 
         # Assert
-        if !isborked
+        if !broken_system
             @test output == settings["sample_lib"] # sys lib detected
         else
             @test_broken output == settings["sample_lib"]
         end
-
-        teardown(settings)
-    end
-
-    @testset "find_library finds system lib" begin
-
-        # Arrange
-        settings, isborked = setup_env()
-
-        # Act
-        output = LightGBM.find_library(settings["sample_lib"], [src_dir]) # library should only exist in syspath, not custom path
-
-        # Assert
-        @test output == settings["sample_lib"] # sys lib detected
-
-        teardown(settings)
     end
 
     @testset "find_library returns empty and logs error" begin
-
-        # Arrange
-        settings, _ = setup_env()
-
         # Act and assert
         @test_throws LightGBM.LibraryNotFoundError LightGBM.find_library("lib_that_simply_doesnt_exist", [src_dir])
-
-        teardown(settings)
-
     end
+
+    teardown(settings)
+
 end
 
 end # module


### PR DESCRIPTION
Recent M1 (cross architecture libs) issues and a weird docker image highlight a few circumstances where the assumed-to-be-present libs for the `find_library` tests aren't always present (in the expected forms, i.e. `libname.system_extension`)

To stop this test from failing and causing issues with users, if no such lib is found, the system is declared "broken" and these tests will subsequently be skipped as "broken", which doesn't cause alarming test failure messages.