### PR TITLE
fix: prevent mutation of categorical_feature inside stringifyparams

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -303,8 +303,8 @@ function stringifyparams(estimator::LGBMEstimator; verbosity::Int = 1)
 
         if !isempty(param_value)
             # Convert parameters that contain indices to C's zero-based indices.
-            if in(param_name, INDEXPARAMS)
-                param_value .-= 1
+            if in(param_name, INDEXPARAMS) && typeof(param_value) <: AbstractArray
+                param_value = param_value .- one(eltype(param_value))
             end
 
             if typeof(param_value) <: Array

--- a/test/basic/test_fit.jl
+++ b/test/basic/test_fit.jl
@@ -339,5 +339,27 @@ end
 
 end
 
+@testset "stringifyparams -- convert to zero-based" begin
+    indices = [1, 3, 5, 7, 9]
+    classifier = LightGBM.LGBMClassification(categorical_feature = indices)
+    ds_parameters = LightGBM.stringifyparams(classifier; verbosity=-1)
+
+    expected = "categorical_feature=0,2,4,6,8"
+    @test occursin(expected, ds_parameters)
+end
+
+@testset "stringifyparams -- multiple calls won't mutate fields" begin
+    indices = [1, 3, 5, 7, 9]
+    classifier = LightGBM.LGBMClassification(categorical_feature = indices)
+    expected_indices = deepcopy(classifier.categorical_feature)
+    
+    LightGBM.stringifyparams(classifier; verbosity=-1)
+    @test expected_indices == classifier.categorical_feature
+
+    LightGBM.stringifyparams(classifier; verbosity=-1)
+    @test expected_indices == classifier.categorical_feature
+end
+
+
 
 end # module

--- a/test/basic/test_utils.jl
+++ b/test/basic/test_utils.jl
@@ -17,6 +17,16 @@ y_train_regression = rand(1000)
 end
 
 
+@testset "stringifyparams -- multiple calls won't mutate fields" begin
+    indices = [1, 3, 5, 7, 9]
+    classifier = LightGBM.LGBMClassification(categorical_feature = indices)
+    LightGBM.stringifyparams(classifier; verbosity=-1)
+    ds_parameters = LightGBM.stringifyparams(classifier; verbosity=-1)
+
+    expected = "categorical_feature=0,2,4,6,8"
+    @test occursin(expected, ds_parameters)
+end
+
 
 @testset "loadmodel predicts same as original model -- regression" begin
     # Arrange

--- a/test/basic/test_utils.jl
+++ b/test/basic/test_utils.jl
@@ -21,10 +21,10 @@ end
     indices = [1, 3, 5, 7, 9]
     classifier = LightGBM.LGBMClassification(categorical_feature = indices)
     LightGBM.stringifyparams(classifier; verbosity=-1)
-    ds_parameters = LightGBM.stringifyparams(classifier; verbosity=-1)
+    @test indices == classifier.categorical_feature
 
-    expected = "categorical_feature=0,2,4,6,8"
-    @test occursin(expected, ds_parameters)
+    LightGBM.stringifyparams(classifier; verbosity=-1)
+    @test indices == classifier.categorical_feature
 end
 
 

--- a/test/basic/test_utils.jl
+++ b/test/basic/test_utils.jl
@@ -7,26 +7,6 @@ X_train = randn(1000, 20)
 y_train_binary = rand(0:1, 1000)
 y_train_regression = rand(1000)
 
-@testset "stringifyparams -- convert to zero-based" begin
-    indices = [1, 3, 5, 7, 9]
-    classifier = LightGBM.LGBMClassification(categorical_feature = indices)
-    ds_parameters = LightGBM.stringifyparams(classifier; verbosity=-1)
-
-    expected = "categorical_feature=0,2,4,6,8"
-    @test occursin(expected, ds_parameters)
-end
-
-
-@testset "stringifyparams -- multiple calls won't mutate fields" begin
-    indices = [1, 3, 5, 7, 9]
-    classifier = LightGBM.LGBMClassification(categorical_feature = indices)
-    LightGBM.stringifyparams(classifier; verbosity=-1)
-    @test indices == classifier.categorical_feature
-
-    LightGBM.stringifyparams(classifier; verbosity=-1)
-    @test indices == classifier.categorical_feature
-end
-
 
 @testset "loadmodel predicts same as original model -- regression" begin
     # Arrange

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -167,7 +167,7 @@ end
     dataset = LightGBM.LGBM_DatasetCreateFromMat(mymat, verbosity)
     LightGBM.LGBM_DatasetSetField(dataset, "label", labels)
     # default params won't allow this to learn anything from this useless data set (i.e. splitting completes)
-    booster = LightGBM.LGBM_BoosterCreate(dataset, verbosity)
+    booster = LightGBM.LGBM_BoosterCreate(dataset, "objective=none $verbosity")
 
     finished = LightGBM.LGBM_BoosterUpdateOneIterCustom(booster, randn(numdata), ones(numdata))
     pred1 = LightGBM.LGBM_BoosterGetPredict(booster, 0)


### PR DESCRIPTION
Fixes https://github.com/IQVIA-ML/LightGBM.jl/issues/131

Assign to a new variable instead of assigning inplace. This is useful during CV where the model is trained many times.

----
This is a copy of https://github.com/IQVIA-ML/LightGBM.jl/pull/132 but from a cleaner branch