### PR TITLE
`num_threads` for `predict`

### DIFF
--- a/src/predict.jl
+++ b/src/predict.jl
@@ -17,6 +17,8 @@ Use `dropdims` if a vector is required.
     only, `0` includes warning logs, `1` includes info logs, and `> 1` includes debug logs.
 * `is_row_major::Bool`: keyword argument that indicates whether or not `X` is row-major. `true`
     indicates that it is row-major, `false` indicates that it is column-major (Julia's default).
+* `num_threads::Integeger`: keyword argument specifying the number of threads to use
+    for prediction. Default is `-1` which reuses `num_threads` of the estimator.
 
 One can obtain some form of feature importances by averaging SHAP contributions across predictions, i.e.
 `mean(LightGBM.predict(estimator, X; predict_type=3); dims=1)`
@@ -25,6 +27,7 @@ function predict(
     estimator::LGBMEstimator, X::AbstractMatrix{TX}; predict_type::Integer = 0,
     start_iteration::Integer = 0, num_iterations::Integer = -1, verbosity::Integer = 1,
     is_row_major::Bool = false,
+    num_threads::Integer = -1,
 )::Matrix{Float64} where TX <:Real
 
     tryload!(estimator)
@@ -32,7 +35,7 @@ function predict(
     log_debug(verbosity, "Started predicting\n")
 
     prediction = LGBM_BoosterPredictForMat(
-        estimator.booster, X, predict_type, start_iteration, num_iterations, is_row_major
+        estimator.booster, X, predict_type, start_iteration, num_iterations, is_row_major, num_threads
     )
 
     # This works the same one way or another because when n=1, (regression) reshaping is basically no-op
@@ -47,13 +50,14 @@ end
 function predict_classes(
     estimator::LGBMClassification, X::AbstractMatrix{TX}; predict_type::Integer = 0,
     num_iterations::Integer = -1, verbosity::Integer = 1,
-    is_row_major::Bool = false, binary_threshold::Float64 = 0.5
+    is_row_major::Bool = false, binary_threshold::Float64 = 0.5,
+    num_threads::Integer = -1,
 ) where TX <:Real
 
     # pass through, get probabilities
     predicted_probabilities = predict(
         estimator, X; predict_type=predict_type, num_iterations=num_iterations,
-        verbosity=verbosity, is_row_major=is_row_major,
+        verbosity=verbosity, is_row_major=is_row_major, num_threads=num_threads,
     )
 
     # binary case

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -668,7 +668,8 @@ function LGBM_BoosterPredictForMat(
     predict_type::Integer,
     start_iteration::Integer,
     num_iteration::Integer,
-    is_row_major::Bool = false
+    is_row_major::Bool = false,
+    num_threads::Integer = -1
 ) where T<:Union{Float32,Float64}
 
     lgbm_data_type = jltype_to_lgbmid(T)
@@ -678,6 +679,9 @@ function LGBM_BoosterPredictForMat(
     out_result = Array{Cdouble}(undef, alloc_len)
 
     parameter = ""  # full prediction, no early stopping
+    if num_threads > 0
+        parameter = "num_threads=$num_threads"
+    end
     @lightgbm(
         :LGBM_BoosterPredictForMat,
         bst.handle => BoosterHandle,

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -361,6 +361,9 @@ end
 
     preds = LightGBM.LGBM_BoosterPredictForMat(booster, mymat, 0, 0, -1) 
     @test all(iszero, preds)
+
+    preds_threaded = LightGBM.LGBM_BoosterPredictForMat(booster, mymat, 0, 0, -1, false, 2) 
+    @test all(iszero, preds_threaded)
 end
 
 

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -355,10 +355,12 @@ end
 
 
 @testset "LGBM_BoosterPredictForMat" begin
+    mymat = [1. 2.; 3. 4.; 5. 6.]
+    dataset = LightGBM.LGBM_DatasetCreateFromMat(mymat, verbosity)
+    booster = LightGBM.LGBM_BoosterCreate(dataset, verbosity)
 
-    # Needs implementing
-    @test_broken false
-
+    preds = LightGBM.LGBM_BoosterPredictForMat(booster, mymat, 0, 0, -1) 
+    @test all(iszero, preds)
 end
 
 


### PR DESCRIPTION
`predict` by default reuses `num_threads` from training. However LightGBM supports setting a separate `num_threads` for predict. Here is a python example https://github.com/microsoft/LightGBM/issues/4706.

I am not familiar with MLJ interface so I have added a `num_threads` keyword argument only to `predict` and `predict_classes`.

Also some of the test are failing but it appears to be unrelated to this PR (`KeyError: key "LIGHTGBM_EXAMPLES_PATH" not found`)