### PR TITLE
added option for macOS to use LightGBM_jll

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9', '1.10']
-        os:  [windows-latest, ubuntu-latest, macOS-latest]
+        version: ['1.6', '1.7', '1.8', '1.9', '1.10']
+        os:  [windows-latest, ubuntu-latest, macOS-latest, macos-14]
         arch:
           - x64
     env:


### PR DESCRIPTION
- allows macOS users on both Intel and arm-64 architectures to use LightGBM_jll
- leaves other operating system users with the option to use the current pre-compiled binary (Intel), or custom binaries