### PR TITLE
fix LGBMRegression field order

### DIFF
--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -39,8 +39,8 @@ mutable struct LGBMRegression <: LGBMEstimator
     save_binary::Bool
     categorical_feature::Vector{Int}
     use_missing::Bool
-    feature_pre_filter::Bool
     linear_tree::Bool
+    feature_pre_filter::Bool
 
     is_unbalance::Bool
     boost_from_average::Bool


### PR DESCRIPTION
The `linear_tree` field of `LGBMRegression` was added in wrong order, resulting if wild behaviors on regression tasks. 
Given the criticals errors associated from this, it would be well worth pushing a quick fix release. 