### PR TITLE
updates default metric for classifier corresponding to objective

### DIFF
--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -443,7 +443,7 @@ function LGBMClassification(;
     max_cat_threshold = 32,
     cat_l2 = 10.0,
     cat_smooth = 10.0,
-    metric = ["None"],
+    metric = [""],
     metric_freq = 1,
     is_training_metric = false,
     ndcg_at = Int[],


### PR DESCRIPTION
- Closes #83 by changing the default metric for `LGBMClassification` from "None" to "" which uses default metric depending on the pre-defined objective