### PR TITLE
Add lgbm ranker

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,60 @@ filename = pwd() * "/finished.model"
 savemodel(estimator, filename)
 loadmodel!(estimator, filename)
 ```
+# LGBM Ranking Support
+
+LightGBM.jl core includes a separate estimator `LGBMRanking` with parameters suitable for ranking applications as described in [group query](https://lightgbm.readthedocs.io/en/v3.3.5/Parameters.html#query-data). Similar to other
+wrapper libraries it is possible to pass a one-dimensional array with `group` information parameter.
+
+Here's an example of how to use `LGBMRanking`:
+
+
+```julia
+using LightGBM
+
+# Create X_train Matrix
+X_train = [
+    0.3 0.6 0.9;
+    0.1 0.4 0.7;
+    0.5 0.8 1.1;
+    0.3 0.6 0.9;
+    0.7 1.0 1.3;
+    0.2 0.5 0.8;
+    0.1 0.4 0.7;
+    0.4 0.7 1.0;
+]
+
+# Create X_test Matrix
+X_test = [
+    0.6 0.9 1.2;
+    0.2 0.5 0.8;
+]
+
+# Create y_train and y_test arrays
+y_train = [0, 0, 0, 0, 1, 0, 1, 1]
+y_test = [0, 1]
+
+# Create group_train and group_test arrays
+group_train = [2, 2, 4]
+group_test = [1, 1]
+
+# Create ranker model
+ranker = LightGBM.LGBMRanking(
+    num_class = 1,
+    objective = "lambdarank",
+    metric = ["ndcg"],
+    eval_at = [1, 3, 5, 10],
+    learning_rate = 0.1,
+    num_leaves = 31,
+    min_data_in_leaf = 1,
+)
+
+# Fit the model
+LightGBM.fit!(ranker, X_train, Vector(y_train), group = group_train)
+
+# Predict the relevance scores for the test set
+y_pred = LightGBM.predict(ranker, X_test)
+   ```
 
 # MLJ Support
 

--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -83,7 +83,7 @@ MLJModelInterface.@mlj_model mutable struct LGBMRegressor <: MLJModelInterface.D
     metric::Vector{String} = ["l2"]::(all(in.(_, (LGBM_METRICS, ))))
     metric_freq::Int = 1::(_ > 0)
     is_training_metric::Bool = false
-    ndcg_at::Vector{Int} = Vector{Int}([1, 2, 3, 4, 5])::(all(_ .> 0))
+    eval_at::Vector{Int} = Vector{Int}([1, 2, 3, 4, 5])::(all(_ .> 0))
 
     # Implementation parameters
     num_machines::Int = 1::(_ > 0)
@@ -167,7 +167,7 @@ MLJModelInterface.@mlj_model mutable struct LGBMClassifier <: MLJModelInterface.
     metric::Vector{String} = ["None"]::(all(in.(_, (LGBM_METRICS, ))))
     metric_freq::Int = 1::(_ > 0)
     is_training_metric::Bool = false
-    ndcg_at::Vector{Int} = Vector{Int}([1, 2, 3, 4, 5])::(all(_ .> 0))
+    eval_at::Vector{Int} = Vector{Int}([1, 2, 3, 4, 5])::(all(_ .> 0))
 
     # Implementation parameters
     num_machines::Int = 1::(_ > 0)

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -298,7 +298,7 @@ mutable struct LGBMClassification <: LGBMEstimator
     metric::Vector{String}
     metric_freq::Int
     is_training_metric::Bool
-    ndcg_at::Vector{Int}
+    ndcg_at::Vector{Int} #alias it's called eval_at
 
     num_machines::Int
     local_listen_port::Int

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -561,7 +561,6 @@ mutable struct LGBMRanking <: LGBMEstimator
     force_col_wise::Bool
     force_row_wise::Bool
 
-    group_column::String
     lambdarank_truncation_level::Int
     lambdarank_norm::Bool
     label_gain::Vector{Int}
@@ -639,7 +638,6 @@ end
         num_gpu = 1,
         force_col_wise = false,
         force_row_wise = false,
-        group_column = "",
         lambdarank_truncation_level = 30,
         lambdarank_norm = true,
         label_gain = [2^i - 1 for i in 0:30],
@@ -717,7 +715,6 @@ function LGBMRanking(;
     num_gpu = 1,
     force_col_wise = false,
     force_row_wise = false,
-    group_column = "",
     lambdarank_truncation_level = 30,
     lambdarank_norm = true,
     label_gain = [2^i - 1 for i in 0:30],
@@ -737,6 +734,6 @@ function LGBMRanking(;
         uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold, cat_l2, cat_smooth,
         metric, metric_freq, is_training_metric, eval_at, num_machines, local_listen_port, time_out,
         machine_list_file, num_class, device_type, gpu_use_dp, gpu_platform_id, gpu_device_id, num_gpu,
-        force_col_wise, force_row_wise, group_column, lambdarank_truncation_level, lambdarank_norm, label_gain, objective_seed
+        force_col_wise, force_row_wise, lambdarank_truncation_level, lambdarank_norm, label_gain, objective_seed
     )
 end

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -316,7 +316,7 @@ mutable struct LGBMClassification <: LGBMEstimator
     force_row_wise::Bool
 
     group_column::String
-    eval_at::Int
+    eval_at::Vector{Int}
 end
 
 """
@@ -463,7 +463,7 @@ function LGBMClassification(;
     force_col_wise = false,
     force_row_wise = false,
     group_column = "",
-    eval_at = Int,
+    eval_at = Int[1, 2, 3, 4, 5],
 )
 
     return LGBMClassification(

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -314,6 +314,9 @@ mutable struct LGBMClassification <: LGBMEstimator
     num_gpu::Int
     force_col_wise::Bool
     force_row_wise::Bool
+
+    group_column::String
+    eval_at::Int
 end
 
 """
@@ -459,6 +462,8 @@ function LGBMClassification(;
     num_gpu = 1,
     force_col_wise = false,
     force_row_wise = false,
+    group_column = "",
+    eval_at = Int,
 )
 
     return LGBMClassification(
@@ -474,6 +479,6 @@ function LGBMClassification(;
         uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold, cat_l2, cat_smooth,
         metric, metric_freq, is_training_metric, ndcg_at, num_machines, local_listen_port, time_out,
         machine_list_file, num_class, device_type, gpu_use_dp, gpu_platform_id, gpu_device_id, num_gpu,
-        force_col_wise, force_row_wise,
+        force_col_wise, force_row_wise, group_column, eval_at
     )
 end

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -565,6 +565,7 @@ mutable struct LGBMRanking <: LGBMEstimator
     lambdarank_norm::Bool
     label_gain::Vector{Int}
     objective_seed::Int
+    group_column::String
 
 end
 
@@ -642,6 +643,7 @@ end
         lambdarank_norm = true,
         label_gain = [2^i - 1 for i in 0:30],
         objective_seed = 5,
+        group_column = ""
     ])
 
 Return a LGBMRanking estimator.
@@ -719,6 +721,7 @@ function LGBMRanking(;
     lambdarank_norm = true,
     label_gain = [2^i - 1 for i in 0:30],
     objective_seed = 5,
+    group_column = "",
 )
 
     return LGBMRanking(
@@ -734,6 +737,6 @@ function LGBMRanking(;
         uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold, cat_l2, cat_smooth,
         metric, metric_freq, is_training_metric, eval_at, num_machines, local_listen_port, time_out,
         machine_list_file, num_class, device_type, gpu_use_dp, gpu_platform_id, gpu_device_id, num_gpu,
-        force_col_wise, force_row_wise, lambdarank_truncation_level, lambdarank_norm, label_gain, objective_seed
+        force_col_wise, force_row_wise, lambdarank_truncation_level, lambdarank_norm, label_gain, objective_seed, group_column,
     )
 end

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -62,7 +62,7 @@ mutable struct LGBMRegression <: LGBMEstimator
     metric::Vector{String}
     metric_freq::Int
     is_training_metric::Bool
-    ndcg_at::Vector{Int}
+    eval_at::Vector{Int}
 
     num_machines::Int
     local_listen_port::Int
@@ -133,7 +133,7 @@ end
         metric = [\"l2\"],
         metric_freq = 1,
         is_training_metric = false,
-        ndcg_at = Int[],
+        eval_at = Int[1, 2, 3, 4, 5],
         num_machines = 1,
         local_listen_port = 12400,
         time_out = 120,
@@ -202,7 +202,7 @@ function LGBMRegression(;
     metric = ["l2"],
     metric_freq = 1,
     is_training_metric = false,
-    ndcg_at = Int[],
+    eval_at = Int[1, 2, 3, 4, 5],
     num_machines = 1,
     local_listen_port = 12400,
     time_out = 120,
@@ -226,7 +226,7 @@ function LGBMRegression(;
         is_sparse, save_binary, categorical_feature, use_missing, linear_tree, feature_pre_filter,
         is_unbalance, boost_from_average, alpha, drop_rate, max_drop, skip_drop,
         xgboost_dart_mode,uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold,
-        cat_l2, cat_smooth, metric, metric_freq, is_training_metric, ndcg_at, num_machines, local_listen_port, time_out,
+        cat_l2, cat_smooth, metric, metric_freq, is_training_metric, eval_at, num_machines, local_listen_port, time_out,
         machine_list_file, 1, device_type, gpu_use_dp, gpu_platform_id, gpu_device_id, num_gpu,
         force_col_wise, force_row_wise,
     )
@@ -298,7 +298,7 @@ mutable struct LGBMClassification <: LGBMEstimator
     metric::Vector{String}
     metric_freq::Int
     is_training_metric::Bool
-    ndcg_at::Vector{Int} #alias it's called eval_at
+    eval_at::Vector{Int}
 
     num_machines::Int
     local_listen_port::Int
@@ -315,8 +315,6 @@ mutable struct LGBMClassification <: LGBMEstimator
     force_col_wise::Bool
     force_row_wise::Bool
 
-    group_column::String
-    eval_at::Vector{Int}
 end
 
 """
@@ -376,12 +374,12 @@ end
         metric = [\"multi_logloss\"],
         metric_freq = 1,
         is_training_metric = false,
-        ndcg_at = Int[],
+        eval_at = Int[1, 2, 3, 4, 5],
         num_machines = 1,
         local_listen_port = 12400,
         time_out = 120,
         machine_list_file = \"\",
-        num_class = 1,
+        num_class = 2,
         device_type=\"cpu\",
         gpu_use_dp = false,
         gpu_platform_id = -1,
@@ -449,7 +447,7 @@ function LGBMClassification(;
     metric = [""],
     metric_freq = 1,
     is_training_metric = false,
-    ndcg_at = Int[],
+    eval_at = Int[1, 2, 3, 4, 5],
     num_machines = 1,
     local_listen_port = 12400,
     time_out = 120,
@@ -462,8 +460,6 @@ function LGBMClassification(;
     num_gpu = 1,
     force_col_wise = false,
     force_row_wise = false,
-    group_column = "",
-    eval_at = Int[1, 2, 3, 4, 5],
 )
 
     return LGBMClassification(
@@ -477,8 +473,270 @@ function LGBMClassification(;
         categorical_feature, use_missing, linear_tree, feature_pre_filter, is_unbalance, boost_from_average, scale_pos_weight, sigmoid,
         drop_rate, max_drop, skip_drop, xgboost_dart_mode,
         uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold, cat_l2, cat_smooth,
-        metric, metric_freq, is_training_metric, ndcg_at, num_machines, local_listen_port, time_out,
+        metric, metric_freq, is_training_metric, eval_at, num_machines, local_listen_port, time_out,
         machine_list_file, num_class, device_type, gpu_use_dp, gpu_platform_id, gpu_device_id, num_gpu,
-        force_col_wise, force_row_wise, group_column, eval_at
+        force_col_wise, force_row_wise,
+    )
+end
+
+mutable struct LGBMRanking <: LGBMEstimator
+    booster::Booster
+    model::String
+    application::String
+    boosting :: String
+
+    num_iterations::Int
+    learning_rate::Float64
+    num_leaves::Int
+    max_depth::Int
+    tree_learner::String
+    num_threads::Int
+    histogram_pool_size::Float64
+
+    min_data_in_leaf::Int
+    min_sum_hessian_in_leaf::Float64
+    max_delta_step::Float64
+    lambda_l1::Float64
+    lambda_l2::Float64
+    min_gain_to_split::Float64
+    feature_fraction::Float64
+    feature_fraction_bynode::Float64
+    feature_fraction_seed::Int
+    bagging_fraction::Float64
+    pos_bagging_fraction::Float64
+    neg_bagging_fraction::Float64
+
+    bagging_freq::Int
+    bagging_seed::Int
+    early_stopping_round::Int
+    extra_trees::Bool
+    extra_seed::Int
+
+    max_bin::Int
+    bin_construct_sample_cnt::Int
+    data_random_seed::Int
+    init_score::String
+    is_sparse::Bool
+    save_binary::Bool
+    categorical_feature::Vector{Int}
+    use_missing::Bool
+    linear_tree::Bool
+    feature_pre_filter::Bool
+
+    is_unbalance::Bool
+    boost_from_average::Bool
+    scale_pos_weight::Float64
+    sigmoid::Float64
+
+    drop_rate::Float64
+    max_drop::Int
+    skip_drop:: Float64
+    xgboost_dart_mode::Bool
+    uniform_drop::Bool
+    drop_seed::Int
+    top_rate::Float64
+    other_rate::Float64
+    min_data_per_group::Int
+    max_cat_threshold::Int
+    cat_l2::Float64
+    cat_smooth::Float64
+
+    metric::Vector{String}
+    metric_freq::Int
+    is_training_metric::Bool
+    eval_at::Vector{Int}
+
+    num_machines::Int
+    local_listen_port::Int
+    time_out::Int
+    machine_list_file::String
+
+    num_class::Int
+
+    device_type::String
+    gpu_use_dp::Bool
+    gpu_platform_id::Int
+    gpu_device_id::Int
+    num_gpu::Int
+    force_col_wise::Bool
+    force_row_wise::Bool
+
+    group_column::String
+    lambdarank_truncation_level::Int
+    lambdarank_norm::Bool
+    label_gain::Vector{Int}
+    objective_seed::Int
+
+end
+
+"""
+    LGBMRanking(;[
+        objective = "lambdarank",
+        boosting = "gbdt",
+        num_iterations = 10,
+        learning_rate = .1,
+        num_leaves = 127,
+        max_depth = -1,
+        tree_learner = \"serial\",
+        num_threads = Sys.CPU_THREADS,
+        histogram_pool_size = -1.,
+        min_data_in_leaf = 100,
+        min_sum_hessian_in_leaf = 1e-3,
+        max_delta_step = 0.,
+        lambda_l1 = 0.,
+        lambda_l2 = 0.,
+        min_gain_to_split = 0.,
+        feature_fraction = 1.,
+        feature_fraction_bynode = 1.,
+        feature_fraction_seed = 2,
+        bagging_fraction = 1.,
+        pos_bagging_fraction = 1.,
+        neg_bagging_fraction = 1.,
+        bagging_freq = 0,
+        bagging_seed = 3,
+        early_stopping_round = 0,
+        extra_trees = false,
+        extra_seed = 6,
+        max_bin = 255,
+        bin_construct_sample_cnt = 200000,
+        data_random_seed = 1,
+        init_score = \"\",
+        is_sparse = true,
+        save_binary = false,
+        categorical_feature = Int[],
+        use_missing = true,
+        linear_tree = false,
+        feature_pre_filter = true,
+        is_unbalance = false,
+        boost_from_average = true,
+        scale_pos_weight = 1.0,
+        sigmoid = 1.0,
+        drop_rate = 0.1,
+        max_drop = 50,
+        skip_drop = 0.5,
+        xgboost_dart_mode = false,
+        uniform_drop = false,
+        drop_seed = 4,
+        top_rate = 0.2,
+        other_rate = 0.1,
+        min_data_per_group = 100,
+        max_cat_threshold = 32,
+        cat_l2 = 10.0,
+        cat_smooth = 10.0,
+        metric = [\"multi_logloss\"],
+        metric_freq = 1,
+        is_training_metric = false,
+        eval_at = Int[1, 2, 3, 4, 5],
+        num_machines = 1,
+        local_listen_port = 12400,
+        time_out = 120,
+        machine_list_file = \"\",
+        num_class = 1,
+        device_type=\"cpu\",
+        gpu_use_dp = false,
+        gpu_platform_id = -1,
+        gpu_device_id = -1,
+        num_gpu = 1,
+        force_col_wise = false,
+        force_row_wise = false,
+        group_column = "",
+        lambdarank_truncation_level = 30,
+        lambdarank_norm = true,
+        label_gain = [2^i - 1 for i in 0:30],
+        objective_seed = 5,
+    ])
+
+Return a LGBMRanking estimator.
+"""
+function LGBMRanking(;
+    objective = "lambdarank",
+    boosting = "gbdt",
+    num_iterations = 10,
+    learning_rate = .1,
+    num_leaves = 127,
+    max_depth = -1,
+    tree_learner = "serial",
+    num_threads = Sys.CPU_THREADS,
+    histogram_pool_size = -1.,
+    min_data_in_leaf = 100,
+    min_sum_hessian_in_leaf = 1e-3,
+    max_delta_step = 0.,
+    lambda_l1 = 0.,
+    lambda_l2 = 0.,
+    min_gain_to_split = 0.,
+    feature_fraction = 1.,
+    feature_fraction_bynode = 1.,
+    feature_fraction_seed = 2,
+    bagging_fraction = 1.,
+    pos_bagging_fraction = 1.,
+    neg_bagging_fraction = 1.,
+    bagging_freq = 0,
+    bagging_seed = 3,
+    early_stopping_round = 0,
+    extra_trees = false,
+    extra_seed = 6,
+    max_bin = 255,
+    bin_construct_sample_cnt = 200000,
+    data_random_seed = 1,
+    init_score = "",
+    is_sparse = true,
+    save_binary = false,
+    categorical_feature = Int[],
+    use_missing = true,
+    linear_tree = false,
+    feature_pre_filter = true,
+    is_unbalance = false,
+    boost_from_average = true,
+    scale_pos_weight = 1.0,
+    sigmoid = 1.0,
+    drop_rate = 0.1,
+    max_drop = 50,
+    skip_drop = 0.5,
+    xgboost_dart_mode = false,
+    uniform_drop = false,
+    drop_seed = 4,
+    top_rate = 0.2,
+    other_rate = 0.1,
+    min_data_per_group = 100,
+    max_cat_threshold = 32,
+    cat_l2 = 10.0,
+    cat_smooth = 10.0,
+    metric = [""],
+    metric_freq = 1,
+    is_training_metric = false,
+    eval_at = Int[1, 2, 3, 4, 5],
+    num_machines = 1,
+    local_listen_port = 12400,
+    time_out = 120,
+    machine_list_file = "",
+    num_class = 1,
+    device_type="cpu",
+    gpu_use_dp = false,
+    gpu_platform_id = -1,
+    gpu_device_id = -1,
+    num_gpu = 1,
+    force_col_wise = false,
+    force_row_wise = false,
+    group_column = "",
+    lambdarank_truncation_level = 30,
+    lambdarank_norm = true,
+    label_gain = [2^i - 1 for i in 0:30],
+    objective_seed = 5,
+)
+
+    return LGBMRanking(
+        Booster(), "", objective, boosting, num_iterations, learning_rate,
+        num_leaves, max_depth, tree_learner, num_threads, histogram_pool_size,
+        min_data_in_leaf, min_sum_hessian_in_leaf, max_delta_step, lambda_l1, lambda_l2,
+        min_gain_to_split, feature_fraction, feature_fraction_bynode, feature_fraction_seed,
+        bagging_fraction, pos_bagging_fraction, neg_bagging_fraction,bagging_freq,
+        bagging_seed, early_stopping_round, extra_trees, extra_seed, max_bin, bin_construct_sample_cnt,
+        data_random_seed, init_score, is_sparse, save_binary,
+        categorical_feature, use_missing, linear_tree, feature_pre_filter, is_unbalance, boost_from_average, scale_pos_weight, sigmoid,
+        drop_rate, max_drop, skip_drop, xgboost_dart_mode,
+        uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold, cat_l2, cat_smooth,
+        metric, metric_freq, is_training_metric, eval_at, num_machines, local_listen_port, time_out,
+        machine_list_file, num_class, device_type, gpu_use_dp, gpu_platform_id, gpu_device_id, num_gpu,
+        force_col_wise, force_row_wise, group_column, lambdarank_truncation_level, lambdarank_norm, label_gain, objective_seed
     )
 end

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -1,5 +1,13 @@
 """
-    fit!(estimator, num_iterations, X, y[, test...]; [verbosity = 1, is_row_major = false])
+    fit!(
+    estimator::LGBMEstimator, X::AbstractMatrix{TX}, y::Vector{Ty}, test::Tuple{AbstractMatrix{TX},Vector{Ty}}...;
+    verbosity::Integer = 1,
+    is_row_major = false,
+    weights::Vector{Tw} = Float32[],
+    init_score::Vector{Ti} = Float64[],
+    group::Vector{Int} = Int[],
+    truncate_booster::Bool=true,
+) where {TX<:Real,Ty<:Real,Tw<:Real,Ti<:Real}
     fit!(estimator, X, y[, test...]; [verbosity = 1, is_row_major = false])
     fit!(estimator, X, y, train_indices[, test_indices...]; [verbosity = 1, is_row_major = false])
     fit!(estimator, train_dataset[, test_datasets...]; [verbosity = 1])
@@ -38,6 +46,7 @@ function fit!(
     is_row_major = false,
     weights::Vector{Tw} = Float32[],
     init_score::Vector{Ti} = Float64[],
+    group::Vector{Int} = Int[],
     truncate_booster::Bool=true,
 ) where {TX<:Real,Ty<:Real,Tw<:Real,Ti<:Real}
 
@@ -52,6 +61,9 @@ function fit!(
     end
     if length(init_score) > 0
         LGBM_DatasetSetField(train_ds, "init_score", init_score)
+    end
+    if length(group) > 0
+        LGBM_DatasetSetField(train_ds, "group", group)
     end
 
     test_dss = []

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -39,6 +39,7 @@ array that holds the validation metric's value at each iteration.
     Should be consistent across train/test. Does not apply to `SparseArrays.SparseMatrixCSC` or `Dataset` constructors.
 * `weights::Vector{Tw<:Real}`: the training weights.
 * `init_score::Vector{Ti<:Real}`: the init scores.
+* `group::Vector{Int}`: group size information for ranking tasks.
 """
 function fit!(
     estimator::LGBMEstimator, X::AbstractMatrix{TX}, y::Vector{Ty}, test::Tuple{AbstractMatrix{TX},Vector{Ty}}...;

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -46,8 +46,7 @@ function fit!(
     is_row_major = false,
     weights::Vector{Tw} = Float32[],
     init_score::Vector{Ti} = Float64[],
-    group::Vector{Int} = Int64[],
-    test_group::Vector{Int} = Int64[],
+    group::Vector{Int} = Int[],
     truncate_booster::Bool=true,
 ) where {TX<:Real,Ty<:Real,Tw<:Real,Ti<:Real}
 
@@ -65,9 +64,6 @@ function fit!(
     end
     if length(group) > 0
         LGBM_DatasetSetField(train_ds, "group", group)
-    end
-    if length(test_group) > 0
-        LGBM_DatasetSetField(train_ds, "test_group", test_group)
     end
 
     test_dss = []

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -38,8 +38,9 @@ array that holds the validation metric's value at each iteration.
     indicates that it is row-major, `false` indicates that it is column-major (Julia's default).
     Should be consistent across train/test. Does not apply to `SparseArrays.SparseMatrixCSC` or `Dataset` constructors.
 * `weights::Vector{Tw<:Real}`: the training weights.
-* `init_score::Vector{Ti<:Real}`: the init scores.
+* `init_score::Vector{Ti<:Real}`: the init scores. 
 * `group::Vector{Int}`: group size information for ranking tasks.
+* `truncate_booster::Bool`: allows to reduce the size of the model by removing less impactful trees. Default is `true`.
 """
 function fit!(
     estimator::LGBMEstimator, X::AbstractMatrix{TX}, y::Vector{Ty}, test::Tuple{AbstractMatrix{TX},Vector{Ty}}...;

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -46,7 +46,8 @@ function fit!(
     is_row_major = false,
     weights::Vector{Tw} = Float32[],
     init_score::Vector{Ti} = Float64[],
-    group::Vector{Int} = Int[],
+    group::Vector{Int} = Int64[],
+    test_group::Vector{Int} = Int64[],
     truncate_booster::Bool=true,
 ) where {TX<:Real,Ty<:Real,Tw<:Real,Ti<:Real}
 
@@ -64,6 +65,9 @@ function fit!(
     end
     if length(group) > 0
         LGBM_DatasetSetField(train_ds, "group", group)
+    end
+    if length(test_group) > 0
+        LGBM_DatasetSetField(train_ds, "test_group", test_group)
     end
 
     test_dss = []

--- a/test/integration/groupQueryTest.jl
+++ b/test/integration/groupQueryTest.jl
@@ -8,20 +8,26 @@ using LightGBM
 
 #=
 The below code is a direct translation of the following Python code:
-import pandas as pd
 import lightgbm as lgb
-# Create X_train DataFrame
-X_train = pd.DataFrame({
-    'var1' : [0.3, 0.1, 0.5, 0.3, 0.7, 0.2, 0.1, 0.4],
-    'var2' : [0.6, 0.4, 0.8, 0.6, 1.0, 0.5, 0.4, 0.7],
-    'var3' : [0.9, 0.7, 1.1, 0.9, 1.3, 0.8, 0.7, 1.0],
-})
-# Create X_test DataFrame
-X_test = pd.DataFrame({
-    'var1' : [0.6, 0.2],
-    'var2' : [0.9, 0.5],
-    'var3' : [1.2, 0.8],
-})
+import numpy as np
+
+# Create X_train numpy array
+X_train = np.array([
+    [0.3, 0.6, 0.9],
+    [0.1, 0.4, 0.7],
+    [0.5, 0.8, 1.1],
+    [0.3, 0.6, 0.9],
+    [0.7, 1.0, 1.3],
+    [0.2, 0.5, 0.8],
+    [0.1, 0.4, 0.7],
+    [0.4, 0.7, 1.0],
+])
+
+# Create X_test numpy array
+X_test = np.array([
+    [0.6, 0.9, 1.2],
+    [0.2, 0.5, 0.8],
+])
 # Create y_train and y_test arrays
 y_train = [0, 0, 0, 0, 1, 0, 1, 1]
 y_test = [0, 1]
@@ -91,7 +97,7 @@ y_pred = ranker.predict(X_test)
     # Predict the relevance scores for the test set
     y_pred = LightGBM.predict(ranker, X_test)
 
-    # Test the predicted scores are as expected
+    # Test the predicted scores are as expected to match with python's output
     @test y_pred ≈ [0.3713922520492622; -0.15637136430479565] atol=1e-6
 
 end

--- a/test/integration/groupQueryTest.jl
+++ b/test/integration/groupQueryTest.jl
@@ -67,10 +67,19 @@ y_pred = ranker.predict(X_test)
     ]
 
     # Create X_test Matrix
-    X_test = [
+    X_test1 = [
         0.6 0.9 1.2;
         0.2 0.5 0.8;
     ]
+
+    # Create second X_test Matrix
+    X_test2 = [
+        0.1 0.3 0.5;
+        0.4 0.6 0.8;
+    ]
+
+    # Create third X_test Matrix as a combination of the first and second
+    X_test3 = vcat(X_test1, X_test2)
 
     # Create y_train and y_test arrays
     y_train = [0, 0, 0, 0, 1, 0, 1, 1]
@@ -94,11 +103,21 @@ y_pred = ranker.predict(X_test)
     # Fit the model
     LightGBM.fit!(ranker, X_train, Vector(y_train), group = group_train)
 
-    # Predict the relevance scores for the test set
-    y_pred = LightGBM.predict(ranker, X_test)
+   # Predict the relevance scores for the test sets
+   y_pred1 = LightGBM.predict(ranker, X_test1)
+   y_pred2 = LightGBM.predict(ranker, X_test2)
+   y_pred3 = LightGBM.predict(ranker, X_test3)
 
-    # Test the predicted scores are as expected to match with python's output
-    @test y_pred ≈ [0.3713922520492622; -0.15637136430479565] atol=1e-6
+   # Test the predicted scores are as expected to match with python's output
+   @test y_pred1 ≈ [0.3713922520492622; -0.15637136430479565] atol=1e-6
+   # The LightGBM .predict() function does not consider group information as the predicted results are the relevance scores
+   # and the group parameter is not used in the prediction process.
+   # The group information is used during training to calculate relevance scores which can be further used
+   # to derive ranking order by sorting those predictions/relevance scores
+   # where the highest score corresponds to the highest rank.
+   # The test below verifies the correctness of predicted scores and ensures that y_pred3
+   # accurately represents a combination of predictions from the first two test sets.
+   @test vcat(y_pred1, y_pred2) ≈ y_pred3 atol=1e-6
 
 end
 

--- a/test/integration/groupQueryTest.jl
+++ b/test/integration/groupQueryTest.jl
@@ -1,0 +1,100 @@
+# Tests that the weighting scheme works for binary_classification
+
+module TestGroupQuery
+
+using Test
+using LightGBM
+
+
+#=
+The below code is a direct translation of the following Python code:
+import pandas as pd
+import lightgbm as lgb
+# Create X_train DataFrame
+X_train = pd.DataFrame({
+    'var1' : [0.3, 0.1, 0.5, 0.3, 0.7, 0.2, 0.1, 0.4],
+    'var2' : [0.6, 0.4, 0.8, 0.6, 1.0, 0.5, 0.4, 0.7],
+    'var3' : [0.9, 0.7, 1.1, 0.9, 1.3, 0.8, 0.7, 1.0],
+})
+# Create X_test DataFrame
+X_test = pd.DataFrame({
+    'var1' : [0.6, 0.2],
+    'var2' : [0.9, 0.5],
+    'var3' : [1.2, 0.8],
+})
+# Create y_train and y_test arrays
+y_train = [0, 0, 0, 0, 1, 0, 1, 1]
+y_test = [0, 1]
+# Create group_train and group_test arrays
+group_train = [2, 2, 4]
+group_test = [1, 1]
+# Create a ranker with the specified parameters
+ranker = lgb.LGBMRanker(
+    objective = 'lambdarank',
+    metric = 'ndcg',
+    ndcg_eval_at = [1, 3, 5, 10],
+    learning_rate = 0.1,
+    num_leaves = 31,
+    min_data_in_leaf = 1,
+    verbose =  -1,
+)
+# Train the model
+ranker.fit(X_train, y_train, group=group_train)
+# Predict the relevance scores for the test set
+y_pred = ranker.predict(X_test)
+# >>> y_pred
+# array([ 0.37139225, -0.15637136])
+=#
+@testset "Group Query information for training data" begin
+
+
+    # Create X_train Matrix
+    X_train = [
+        0.3 0.6 0.9;
+        0.1 0.4 0.7;
+        0.5 0.8 1.1;
+        0.3 0.6 0.9;
+        0.7 1.0 1.3;
+        0.2 0.5 0.8;
+        0.1 0.4 0.7;
+        0.4 0.7 1.0;
+    ]
+
+    # Create X_test Matrix
+    X_test = [
+        0.6 0.9 1.2;
+        0.2 0.5 0.8;
+    ]
+
+    # Create y_train and y_test arrays
+    y_train = [0, 0, 0, 0, 1, 0, 1, 1]
+    y_test = [0, 1]
+
+    # Create group_train and group_test arrays
+    group_train = [2, 2, 4]
+    group_test = [1, 1]
+
+    # Create ranker model
+    ranker = LightGBM.LGBMRanking(
+        num_class = 1,
+        objective = "lambdarank",
+        metric = ["ndcg"],
+        eval_at = [1, 3, 5, 10],
+        learning_rate = 0.1,
+        num_leaves = 31,
+        min_data_in_leaf = 1,
+    )
+
+    # Fit the model
+    LightGBM.fit!(ranker, X_train, Vector(y_train), group = group_train)
+
+    # Predict the relevance scores for the test set
+    y_pred = LightGBM.predict(ranker, X_test)
+
+    # Test the predicted scores are as expected
+    @test y_pred ≈ [0.3713922520492622; -0.15637136430479565] atol=1e-6
+
+end
+
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,4 +100,8 @@ end
         include("integration/initScoreTest.jl")
     end
 
+    @testset "Group Query Test" begin
+        include("integration/groupQueryTest.jl")
+    end
+
 end


### PR DESCRIPTION
-  closes #118:
  - by adding a separate ranking estimator 
  - adding group query info as a vector of ints that can be passed to the fit method for training data similarly to weight and input score data rather than through a separate `group_column` parameter requiring additional .txt files for query and training data [ref: query data](https://lightgbm.readthedocs.io/en/v3.3.5/Parameters.html#query-data)
-  matches with the provided python equivalent for fit and predictions (added to tests)

