### PR TITLE
Implement lgbm booster refit

### DIFF
--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -70,6 +70,7 @@ MLJModelInterface.@mlj_model mutable struct LGBMRegressor <: MLJModelInterface.D
     max_cat_threshold::Int = 32::(_ > 0)
     cat_l2::Float64 = 10.0::(_ >= 0)
     cat_smooth::Float64 = 10.0::(_ >= 0)
+    refit_decay_rate::Float64 = 0.9::(0.0 <= _ <= 1.0)
     
     # Dataset parameters
     linear_tree::Bool = false
@@ -165,6 +166,7 @@ MLJModelInterface.@mlj_model mutable struct LGBMClassifier <: MLJModelInterface.
     max_cat_threshold::Int = 32::(_ > 0)
     cat_l2::Float64 = 10.0::(_ >= 0)
     cat_smooth::Float64 = 10.0::(_ >= 0)
+    refit_decay_rate::Float64 = 0.9::(0.0 <= _ <= 1.0)
     
     # Dateset parameters
     linear_tree::Bool = false

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -47,6 +47,7 @@ mutable struct LGBMRegression <: LGBMEstimator
     max_cat_threshold::Int
     cat_l2::Float64
     cat_smooth::Float64
+    refit_decay_rate::Float64
     
     # Dataset parameters
     linear_tree::Bool
@@ -132,6 +133,7 @@ end
         max_cat_threshold = 32,
         cat_l2 = 10.,
         cat_smooth = 10.,
+        refit_decay_rate = 0.9,
         linear_tree = false,
         max_bin = 255,
         bin_construct_sample_cnt = 200000,
@@ -205,6 +207,7 @@ function LGBMRegression(;
     max_cat_threshold = 32,
     cat_l2 = 10.,
     cat_smooth = 10.,
+    refit_decay_rate = 0.9,
     linear_tree = false,
     max_bin = 255,
     bin_construct_sample_cnt = 200000,
@@ -244,7 +247,7 @@ function LGBMRegression(;
         extra_seed, early_stopping_round, max_delta_step, lambda_l1, lambda_l2,
         min_gain_to_split, drop_rate, max_drop, skip_drop,
         xgboost_dart_mode, uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold,
-        cat_l2, cat_smooth, linear_tree, max_bin, bin_construct_sample_cnt, data_random_seed,
+        cat_l2, cat_smooth, refit_decay_rate, linear_tree, max_bin, bin_construct_sample_cnt, data_random_seed,
         is_enable_sparse, use_missing, feature_pre_filter, categorical_feature, 
         start_iteration_predict, num_iteration_predict, predict_raw_score, predict_leaf_index, predict_contrib, predict_disable_shape_check, 
         1, is_unbalance, boost_from_average, alpha, metric, metric_freq, is_provide_training_metric, eval_at, num_machines, local_listen_port, time_out,
@@ -301,6 +304,7 @@ mutable struct LGBMClassification <: LGBMEstimator
     max_cat_threshold::Int
     cat_l2::Float64
     cat_smooth::Float64
+    refit_decay_rate::Float64
 
     # Dataset parameters
     linear_tree::Bool
@@ -392,6 +396,7 @@ end
         max_cat_threshold = 32,
         cat_l2 = 10.,
         cat_smooth = 10.,
+        refit_decay_rate = 0.9,
         linear_tree = false,
         max_bin = 255,
         bin_construct_sample_cnt = 200000,
@@ -472,6 +477,7 @@ function LGBMClassification(;
     max_cat_threshold = 32,
     cat_l2 = 10.,
     cat_smooth = 10.,
+    refit_decay_rate = 0.9,
     linear_tree = false,
     max_bin = 255,
     bin_construct_sample_cnt = 200000,
@@ -515,7 +521,7 @@ function LGBMClassification(;
         bagging_fraction, pos_bagging_fraction, neg_bagging_fraction,bagging_freq,
         bagging_seed, feature_fraction, feature_fraction_bynode, feature_fraction_seed, extra_trees, extra_seed, early_stopping_round, max_delta_step, lambda_l1, lambda_l2,
         min_gain_to_split, drop_rate, max_drop, skip_drop, xgboost_dart_mode,
-        uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold, cat_l2, cat_smooth, linear_tree, max_bin, bin_construct_sample_cnt,
+        uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold, cat_l2, cat_smooth, refit_decay_rate, linear_tree, max_bin, bin_construct_sample_cnt,
         data_random_seed, is_enable_sparse, use_missing, feature_pre_filter, categorical_feature, 
         start_iteration_predict, num_iteration_predict, predict_raw_score, predict_leaf_index, predict_contrib,
         predict_disable_shape_check, pred_early_stop, pred_early_stop_freq, pred_early_stop_margin,
@@ -573,6 +579,7 @@ mutable struct LGBMRanking <: LGBMEstimator
     max_cat_threshold::Int
     cat_l2::Float64
     cat_smooth::Float64
+    refit_decay_rate::Float64
 
     # Dataset parameters
     linear_tree::Bool
@@ -669,6 +676,7 @@ end
         max_cat_threshold = 32,
         cat_l2 = 10.,
         cat_smooth = 10.,
+        refit_decay_rate = 0.9,
         linear_tree = false,
         max_bin = 255,
         bin_construct_sample_cnt = 200000,
@@ -754,6 +762,7 @@ function LGBMRanking(;
     max_cat_threshold = 32,
     cat_l2 = 10.,
     cat_smooth = 10.,
+    refit_decay_rate = 0.9,
     linear_tree = false,
     max_bin = 255,
     bin_construct_sample_cnt = 200000,
@@ -802,7 +811,7 @@ function LGBMRanking(;
         bagging_fraction, pos_bagging_fraction, neg_bagging_fraction, bagging_freq,
         bagging_seed, feature_fraction, feature_fraction_bynode, feature_fraction_seed, extra_trees, extra_seed, early_stopping_round, max_delta_step, lambda_l1, lambda_l2,
         min_gain_to_split, drop_rate, max_drop, skip_drop, xgboost_dart_mode,
-        uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold, cat_l2, cat_smooth, linear_tree, max_bin, bin_construct_sample_cnt,
+        uniform_drop, drop_seed, top_rate, other_rate, min_data_per_group, max_cat_threshold, cat_l2, cat_smooth, refit_decay_rate, linear_tree, max_bin, bin_construct_sample_cnt,
         data_random_seed, is_enable_sparse, use_missing, feature_pre_filter, group_column, categorical_feature, 
         start_iteration_predict, num_iteration_predict, predict_raw_score, predict_leaf_index, predict_contrib,
         predict_disable_shape_check, pred_early_stop, pred_early_stop_freq, pred_early_stop_margin,

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -690,6 +690,21 @@ function LGBM_BoosterPredictForMat(bst::Booster, data::Matrix{T}, predict_type::
                                      num_iteration)
 end
 
+function LGBM_BoosterRefit(bst::Booster, leaf_preds::Matrix{Float64})
+    nrow, ncol = size(leaf_preds)
+    # input matrix is Float64 (when comes from predictions), but leaf indices are Int32
+    leaf_preds = convert(Matrix{Int32}, leaf_preds)
+    
+    @lightgbm(
+        :LGBM_BoosterRefit,
+        bst.handle => BoosterHandle,
+        leaf_preds => Ptr{Int32},
+        nrow => Int32,
+        ncol => Int32
+    )
+    return nothing
+end
+
 function LGBM_BoosterSaveModel(
     bst::Booster,
     start_iteration::Integer,

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -690,10 +690,8 @@ function LGBM_BoosterPredictForMat(bst::Booster, data::Matrix{T}, predict_type::
                                      num_iteration)
 end
 
-function LGBM_BoosterRefit(bst::Booster, leaf_preds::Matrix{Float64})
+function LGBM_BoosterRefit(bst::Booster, leaf_preds::Matrix{Int32})
     nrow, ncol = size(leaf_preds)
-    # input matrix is Float64 (when comes from predictions), but leaf indices are Int32
-    leaf_preds = convert(Matrix{Int32}, leaf_preds)
     
     @lightgbm(
         :LGBM_BoosterRefit,

--- a/test/basic/test_parameters.jl
+++ b/test/basic/test_parameters.jl
@@ -191,8 +191,7 @@ end
 @testset "parameters -- prediction" begin
     # Generate random data
     X_train = randn(1000, 20)
-    y_train_classifier = rand([0, 1], 1000)
-    y_train_regressor = randn(1000)
+    y_train = rand([0, 1], 1000)
 
     # Define combinations of parameters
     combinations = [
@@ -225,7 +224,7 @@ end
             if model_type == LightGBM.LGBMClassification
                 estimator.num_class = 1
             end
-            LightGBM.fit!(estimator, X_train, y_train_classifier, verbosity = -1)
+            LightGBM.fit!(estimator, X_train, y_train, verbosity = -1)
             push!(estimators, estimator)
         end
         return estimators

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -414,9 +414,6 @@ end
     # Fit the estimator with the training data
     LightGBM.fit!(estimator, X_train, y_train, verbosity = -1)
     
-    # Get the number of trees in the booster
-    num_trees = LightGBM.LGBM_BoosterGetCurrentIteration(estimator.booster)
-    
     # Get the leaf predictions using the training data
     leaf_predictions = LightGBM.predict(estimator, X_train)
     

--- a/test/ffi/booster.jl
+++ b/test/ffi/booster.jl
@@ -403,6 +403,32 @@ end
 end
 
 
+@testset "LGBM_BoosterRefit" begin
+    # Sample dataset
+    X_train = randn(1000, 20)
+    y_train = rand([0, 1], 1000)
+    
+    # Create an estimator with predict_leaf_index set to true to obtain leaf index predictions
+    estimator = LightGBM.LGBMClassification(predict_leaf_index = true, num_iterations = 1)
+    
+    # Fit the estimator with the training data
+    LightGBM.fit!(estimator, X_train, y_train, verbosity = -1)
+    
+    # Get the number of trees in the booster
+    num_trees = LightGBM.LGBM_BoosterGetCurrentIteration(estimator.booster)
+    
+    # Get the leaf predictions using the training data
+    leaf_predictions = LightGBM.predict(estimator, X_train)
+    
+    # Refit the model using leaf predictions
+    result = LightGBM.LGBM_BoosterRefit(estimator.booster, leaf_predictions)
+    
+    # Test that LGBM_BoosterRefit returns nothing (meaning successful)
+    @test result == nothing
+ 
+end
+
+
 @testset "LGBM_BoosterSaveModel" begin
 
     booster = LightGBM.LGBM_BoosterCreateFromModelfile(joinpath(@__DIR__, "data", "test_tree"))


### PR DESCRIPTION
- adds FFI for `LGBM_BoosterRefit`
- partially addresses #7 (as `refit_decay_rate` needs to be implemented as a part of a `refit()` function that uses `LGBM_BoosterRefit and `refit_decay_rate`` so this is bringing the FFI first and the default refit_decay_rate)
