### PR TITLE
updated macOS-12 to macOS-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['1.6', '1.7', '1.8', '1.9', '1.10']
-        os:  [windows-latest, ubuntu-latest, macOS-12, macOS-14]
+        os:  [windows-latest, ubuntu-latest, macOS-latest]
         arch:
           - x64
     env:


### PR DESCRIPTION
- updated CI to use macOS-latest following this: https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/