### PR TITLE
added alignment for zero-based index for interaction_constraints

### DIFF
--- a/src/MLJInterface.jl
+++ b/src/MLJInterface.jl
@@ -86,7 +86,7 @@ MLJModelInterface.@mlj_model mutable struct LGBMRegressor <: MLJModelInterface.D
     cegb_penalty_feature_lazy::Vector{Float64} = Vector{Float64}()
     cegb_penalty_feature_coupled::Vector{Float64} = Vector{Float64}()
     path_smooth::Float64 = 0.0::(_ >= 0.0)
-    interaction_constraints::String = ""
+    interaction_constraints::Vector{Vector{Int}} = Vector{Vector{Int}}()
     verbosity::Int = 1
     
     # Dataset parameters
@@ -209,7 +209,7 @@ MLJModelInterface.@mlj_model mutable struct LGBMClassifier <: MLJModelInterface.
     cegb_penalty_feature_lazy::Vector{Float64} = Vector{Float64}()
     cegb_penalty_feature_coupled::Vector{Float64} = Vector{Float64}()
     path_smooth::Float64 = 0.0::(_ >= 0.0)
-    interaction_constraints::String = ""
+    interaction_constraints::Vector{Vector{Int}} = Vector{Vector{Int}}()
     verbosity::Int = 1
     
     # Dateset parameters

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -63,7 +63,7 @@ mutable struct LGBMRegression <: LGBMEstimator
     cegb_penalty_feature_lazy::Vector{Float64}
     cegb_penalty_feature_coupled::Vector{Float64}
     path_smooth::Float64
-    interaction_constraints::String
+    interaction_constraints::Vector{Vector{Int}}
     verbosity::Int
     
     # Dataset parameters
@@ -176,7 +176,7 @@ end
         cegb_penalty_feature_lazy = Float64[],
         cegb_penalty_feature_coupled = Float64[],
         path_smooth = 0.,
-        interaction_constraints = "",
+        interaction_constraints = Vector{Int}[],
         verbosity = 1,
         linear_tree = false,
         max_bin = 255,
@@ -277,7 +277,7 @@ function LGBMRegression(;
     cegb_penalty_feature_lazy = Float64[],
     cegb_penalty_feature_coupled = Float64[],
     path_smooth = 0.,
-    interaction_constraints = "",
+    interaction_constraints = Vector{Int}[],
     verbosity = 1,
     linear_tree = false,
     max_bin = 255,
@@ -403,7 +403,7 @@ mutable struct LGBMClassification <: LGBMEstimator
     cegb_penalty_feature_lazy::Vector{Float64}
     cegb_penalty_feature_coupled::Vector{Float64}
     path_smooth::Float64
-    interaction_constraints::String
+    interaction_constraints::Vector{Vector{Int}}
     verbosity::Int
 
     # Dataset parameters
@@ -520,7 +520,7 @@ end
         cegb_penalty_feature_lazy = Float64[],
         cegb_penalty_feature_coupled = Float64[],
         path_smooth = 0.
-        interaction_constraints = "",  
+        interaction_constraints = Vector{Int}[],  
         verbosity = 1,
         linear_tree = false,
         max_bin = 255,
@@ -626,7 +626,7 @@ function LGBMClassification(;
     cegb_penalty_feature_lazy = Float64[],
     cegb_penalty_feature_coupled = Float64[],
     path_smooth = 0.,
-    interaction_constraints = "",
+    interaction_constraints = Vector{Int}[],
     verbosity = 1,
     linear_tree = false,
     max_bin = 255,
@@ -755,7 +755,7 @@ mutable struct LGBMRanking <: LGBMEstimator
     cegb_penalty_feature_lazy::Vector{Float64}
     cegb_penalty_feature_coupled::Vector{Float64}
     path_smooth::Float64
-    interaction_constraints::String
+    interaction_constraints::Vector{Vector{Int}}
     verbosity::Int
 
     # Dataset parameters
@@ -875,7 +875,7 @@ end
         cegb_penalty_feature_lazy = Float64[],
         cegb_penalty_feature_coupled = Float64[],
         path_smooth = 0.,
-        interaction_constraints = "",
+        interaction_constraints = Vector{Int}[],
         verbosity = 1,
         linear_tree = false,
         max_bin = 255,
@@ -984,7 +984,7 @@ function LGBMRanking(;
     cegb_penalty_feature_lazy = Float64[],
     cegb_penalty_feature_coupled = Float64[],
     path_smooth = 0.,
-    interaction_constraints = "",
+    interaction_constraints = Vector{Int}[],
     verbosity = 1,
     linear_tree = false,
     max_bin = 255,

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -316,8 +316,10 @@ function stringifyparams(estimator::LGBMEstimator)
 
         if !isempty(param_value)
             # Convert parameters that contain indices to C's zero-based indices.
-            if in(param_name, INDEXPARAMS) && typeof(param_value) <: AbstractArray
-                param_value = param_value .- one(eltype(param_value))
+            if param_name == :interaction_constraints && typeof(param_value) <: Vector{Vector{Int}}
+            param_value = "[" * join(map(x -> join(x .- 1, ","), param_value), "],[") * "]"
+            elseif in(param_name, INDEXPARAMS) && typeof(param_value) <: AbstractArray
+            param_value = param_value .- one(eltype(param_value))
             end
 
             if typeof(param_value) <: Array

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 
-const INDEXPARAMS = [:categorical_feature]
+const INDEXPARAMS = [:categorical_feature, :interaction_constraints]
 
 const MAXIMIZE_METRICS = ["auc", "ndcg", "average_precision"]
 

--- a/test/basic/test_fit.jl
+++ b/test/basic/test_fit.jl
@@ -349,11 +349,17 @@ end
 
 @testset "stringifyparams -- convert to zero-based" begin
     indices = [1, 3, 5, 7, 9]
-    classifier = LightGBM.LGBMClassification(categorical_feature = indices, verbosity = -1)
+    interaction_constraints = [[1, 3], [5, 7], [9]]
+    classifier = LightGBM.LGBMClassification(
+        categorical_feature = indices, 
+        interaction_constraints = interaction_constraints, 
+        verbosity = -1)
     ds_parameters = LightGBM.stringifyparams(classifier)
 
     expected = "categorical_feature=0,2,4,6,8"
+    expected_constraints = "interaction_constraints=[0,2],[4,6],[8]"
     @test occursin(expected, ds_parameters)
+    @test occursin(expected_constraints, ds_parameters)
 end
 
 @testset "stringifyparams -- multiple calls won't mutate fields" begin

--- a/test/basic/test_parameters.jl
+++ b/test/basic/test_parameters.jl
@@ -425,8 +425,8 @@ end
     monotone_penalty = 0.1
     # The below interaction constraints are defined so that features in each vector are allowed to interact with each other
     # The model can consider interactions between those grouped features when buiding trees.
-    # Features that are no included in any interaction constraing group are treated as independent.
-    interaction_constraints = "[1,2],[3,4,5],[6,7,8,9,10]"
+    # Features that are not included in any interaction constraint group are treated as independent.
+    interaction_constraints = [[1,2],[3,4,5],[6,7,8,9,10]]
 
     # Create and fit the estimator with monotone constraints
     estimator_with_monotone_constraints = LightGBM.LGBMClassification(


### PR DESCRIPTION
- added `interaction_constraints` to the `INDEXPARAM`
- updated type for `interaction_constraints` to accept now `Vector{Vector{Int}}` instead of String (default for CLI but supported as a list of list in other languages)
- aligned julia's one-based indexing to the zero-based indexing similar to `categorical_feature`