### PR TITLE
store generic feature names to match tables schema for mlj API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LightGBM"
 uuid = "7acf609c-83a4-11e9-1ffb-b912bcd3b04a"
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/mlj/binary_classifier.jl
+++ b/test/mlj/binary_classifier.jl
@@ -51,6 +51,7 @@ expected_return_type = Tuple{
     LightGBM.LGBMClassification,
     CategoricalArrays.CategoricalArray,
     LightGBM.MLJInterface.LGBMClassifier,
+    Union{Nothing, Tuple},
 }
 
 @test isa(fitresult, expected_return_type)

--- a/test/mlj/multiclass_classifier.jl
+++ b/test/mlj/multiclass_classifier.jl
@@ -51,6 +51,7 @@ expected_return_type = Tuple{
     LightGBM.LGBMClassification,
     CategoricalArrays.CategoricalArray,
     LightGBM.MLJInterface.LGBMClassifier,
+    Union{Nothing, Tuple},
 }
 
 @test isa(fitresult, expected_return_type)

--- a/test/mlj/regression.jl
+++ b/test/mlj/regression.jl
@@ -44,6 +44,7 @@ expected_return_type = Tuple{
     LightGBM.LGBMRegression,
     Vector{Any}, # blep
     LightGBM.MLJInterface.LGBMRegressor,
+    Union{Nothing, Tuple},
 }
 
 @test isa(fitresult, expected_return_type)


### PR DESCRIPTION
- stores generic feature names matching tables schema for mlj API which differ from core lightGBM default feature names